### PR TITLE
Introduced basic_logger class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,23 @@ find_package(MySQL REQUIRED)
 
 set(source_files
   src/app.cpp
+
+  src/binsrv/connection_config_fwd.hpp
   src/binsrv/connection_config.hpp
   src/binsrv/connection_config.cpp
+
+  src/binsrv/basic_logger_fwd.hpp
+  src/binsrv/basic_logger.hpp
+  src/binsrv/basic_logger.cpp
+
+  src/binsrv/ostream_logger.hpp
+  src/binsrv/ostream_logger.cpp
+
+  src/util/command_line_helpers_fwd.hpp
+  src/util/command_line_helpers.hpp
+  src/util/command_line_helpers.cpp
+
+  src/util/exception_helpers.hpp
 )
 
 add_executable(binlog_server ${source_files})

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,54 +1,106 @@
-#include <algorithm>
 #include <cassert>
-#include <filesystem>
+#include <cstdint>
 #include <iostream>
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include <mysql/mysql.h>
 
 #include "binsrv/connection_config.hpp"
+#include "binsrv/ostream_logger.hpp"
+
+#include "util/command_line_helpers.hpp"
+
+[[nodiscard]] std::string get_readable_mysql_client_version() {
+  static constexpr std::uint32_t version_multiplier = 100U;
+  auto mysql_client_version =
+      static_cast<std::uint32_t>(mysql_get_client_version());
+  const std::uint32_t mysql_client_version_patch =
+      mysql_client_version % version_multiplier;
+  mysql_client_version /= version_multiplier;
+  const std::uint32_t mysql_client_version_minor =
+      mysql_client_version % version_multiplier;
+  mysql_client_version /= version_multiplier;
+  const std::uint32_t mysql_client_version_major =
+      mysql_client_version % version_multiplier;
+
+  std::string res;
+  res += std::to_string(mysql_client_version_major);
+  res += '.';
+  res += std::to_string(mysql_client_version_minor);
+  res += '.';
+  res += std::to_string(mysql_client_version_patch);
+
+  return res;
+}
 
 int main(int argc, char *argv[]) {
+  using namespace std::string_literals;
+
   int exit_code = EXIT_FAILURE;
-  if (argc != binsrv::connection_config::expected_number_of_parameters + 1 &&
-      argc != 2) {
-    std::filesystem::path executable_path{argv[0]};
-    auto filename = executable_path.filename();
-    std::cerr << "usage: " << filename << " <host> <port> <user> <password>\n"
-              << "       " << filename << " <json_config_file>\n";
+
+  const auto cmd_args = util::to_command_line_agg_view(argc, argv);
+  const auto number_of_cmd_args = std::size(cmd_args);
+
+  if (number_of_cmd_args !=
+          binsrv::connection_config::expected_number_of_arguments + 1 &&
+      number_of_cmd_args != 2) {
+    auto executable_name = util::extract_executable_name(cmd_args);
+    std::cerr << "usage: " << executable_name
+              << " <host> <port> <user> <password>\n"
+              << "       " << executable_name << " <json_config_file>\n";
     return exit_code;
   }
+  binsrv::basic_logger_ptr logger;
 
   try {
-    using connection_config_ptr = std::unique_ptr<binsrv::connection_config>;
-    connection_config_ptr config;
-    if (argc == 2) {
-      std::cout << "Reading connection configuration from the JSON file.\n";
-      config = std::make_unique<binsrv::connection_config>(argv[1]);
-    } else if (argc ==
-               binsrv::connection_config::expected_number_of_parameters + 1) {
-      std::cout << "Reading connection configuration from the command line "
-                   "parameters.\n";
-      binsrv::connection_config::parameter_container parameters;
-      std::copy(argv + 1, argv + argc, parameters.begin());
-      config = std::make_unique<binsrv::connection_config>(parameters);
+    const auto default_log_level = binsrv::log_severity::trace;
+    logger = std::make_shared<binsrv::ostream_logger>(std::cout);
+    logger->set_min_level(default_log_level);
+    const auto log_level_label =
+        binsrv::to_string_view(logger->get_min_level());
+    // logging with "delimiter" level has the highest priority and empty label
+    logger->log(binsrv::log_severity::delimiter,
+                "logging level set to \""s + std::string{log_level_label} +
+                    '"');
+
+    binsrv::connection_config_ptr config;
+    if (number_of_cmd_args == 2) {
+      logger->log(binsrv::log_severity::info,
+                  "Reading connection configuration from the JSON file.");
+      config = std::make_shared<binsrv::connection_config>(cmd_args[1]);
+    } else if (number_of_cmd_args ==
+               binsrv::connection_config::expected_number_of_arguments + 1) {
+      logger->log(binsrv::log_severity::info,
+                  "Reading connection configuration from the command line "
+                  "parameters.");
+      config = std::make_shared<binsrv::connection_config>(cmd_args);
     } else {
       assert(false);
     }
     assert(config);
-    std::cout << "host    : " << config->get_host() << '\n';
-    std::cout << "port    : " << config->get_port() << '\n';
-    std::cout << "user    : " << config->get_user() << '\n';
-    std::cout << "password: " << config->get_password() << '\n';
 
-    std::cout << '\n';
-    std::cout << "mysql client version: " << mysql_get_client_version() << '\n';
+    logger->log(
+        binsrv::log_severity::info,
+        "mysql connection string: " + config->get_user() + '@' +
+            config->get_host() + ':' + std::to_string(config->get_port()) +
+            (config->get_password().empty() ? " (no password)"
+                                            : " (password ***hidden***)"));
+
+    logger->log(binsrv::log_severity::info,
+                "mysql client version: " + get_readable_mysql_client_version());
 
     exit_code = EXIT_SUCCESS;
   } catch (const std::exception &e) {
-    std::cerr << "std::exception caught: " << e.what() << '\n';
+    if (logger) {
+      logger->log(binsrv::log_severity::error,
+                  "std::exception caught: "s + e.what());
+    }
   } catch (...) {
-    std::cerr << "unhandled exception caught\n";
+    if (logger) {
+      logger->log(binsrv::log_severity::info, "unhandled exception caught");
+    }
   }
 
   return exit_code;

--- a/src/binsrv/basic_logger.cpp
+++ b/src/binsrv/basic_logger.cpp
@@ -1,0 +1,32 @@
+#include "binsrv/basic_logger.hpp"
+
+#include <string>
+#include <string_view>
+
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/date_time/posix_time/ptime.hpp>
+#include <boost/date_time/posix_time/time_formatters_limited.hpp>
+
+namespace binsrv {
+
+void basic_logger::log(log_severity level, std::string_view message) {
+  if (level >= min_level_) {
+    static constexpr auto timestamp_length =
+        std::size("YYYY-MM-DDTHH:MM:SS.fffffffff") - 1;
+    const auto timestamp = boost::posix_time::microsec_clock::universal_time();
+    ;
+    const auto level_label = to_string_view(level);
+    std::string buf;
+    buf.reserve(1 + timestamp_length + 1 + 1 + 1 + std::size(level_label) + 1 +
+                1 + std::size(message));
+    buf += '[';
+    buf += boost::posix_time::to_iso_extended_string(timestamp);
+    buf += "] [";
+    buf += level_label;
+    buf += "] ";
+    buf += message;
+    do_log(buf);
+  }
+}
+
+} // namespace binsrv

--- a/src/binsrv/basic_logger.hpp
+++ b/src/binsrv/basic_logger.hpp
@@ -1,0 +1,66 @@
+#ifndef BINSRV_BASIC_LOGGER_HPP
+#define BINSRV_BASIC_LOGGER_HPP
+
+#include "binsrv/basic_logger_fwd.hpp"
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+#include <type_traits>
+
+namespace binsrv {
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+#define BINSRV_BASIC_LOGGER_X_SEQUENCE()                                       \
+  BINSRV_BASIC_LOGGER_X_MACRO(trace), BINSRV_BASIC_LOGGER_X_MACRO(debug),      \
+      BINSRV_BASIC_LOGGER_X_MACRO(info), BINSRV_BASIC_LOGGER_X_MACRO(warning), \
+      BINSRV_BASIC_LOGGER_X_MACRO(error), BINSRV_BASIC_LOGGER_X_MACRO(fatal)
+
+#define BINSRV_BASIC_LOGGER_X_MACRO(X) X
+enum class log_severity { BINSRV_BASIC_LOGGER_X_SEQUENCE(), delimiter };
+#undef BINSRV_BASIC_LOGGER_X_MACRO
+
+#define BINSRV_BASIC_LOGGER_X_MACRO(X) #X##sv
+inline std::string_view to_string_view(log_severity level) noexcept {
+  using namespace std::string_view_literals;
+  static constexpr std::array labels{BINSRV_BASIC_LOGGER_X_SEQUENCE(), ""sv};
+  const auto index = static_cast<std::size_t>(
+      static_cast<std::underlying_type_t<log_severity>>(
+          std::min(log_severity::delimiter, level)));
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+  return labels[index];
+}
+#undef BINSRV_BASIC_LOGGER_X_MACRO
+#undef BINSRV_BASIC_LOGGER_X_SEQUENCE
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+class basic_logger {
+public:
+  basic_logger(const basic_logger &) = delete;
+  basic_logger &operator=(const basic_logger &) = delete;
+  basic_logger(basic_logger &&) = delete;
+  basic_logger &operator=(basic_logger &&) = delete;
+
+  virtual ~basic_logger() = default;
+
+  [[nodiscard]] log_severity get_min_level() const noexcept {
+    return min_level_;
+  }
+  void set_min_level(log_severity min_level) noexcept {
+    min_level_ = min_level;
+  }
+
+  void log(log_severity level, std::string_view message);
+
+protected:
+  basic_logger() = default;
+
+private:
+  log_severity min_level_{log_severity::info};
+
+  virtual void do_log(std::string_view message) = 0;
+};
+
+} // namespace binsrv
+
+#endif // BINSRV_BASIC_LOGGER_HPP

--- a/src/binsrv/basic_logger_fwd.hpp
+++ b/src/binsrv/basic_logger_fwd.hpp
@@ -1,0 +1,16 @@
+#ifndef BINSRV_BASIC_LOGGER_FWD_HPP
+#define BINSRV_BASIC_LOGGER_FWD_HPP
+
+#include <memory>
+
+namespace binsrv {
+
+enum class log_severity;
+
+class basic_logger;
+
+using basic_logger_ptr = std::shared_ptr<basic_logger>;
+
+} // namespace binsrv
+
+#endif // BINSRV_BASIC_LOGGER_FWD_HPP

--- a/src/binsrv/connection_config.cpp
+++ b/src/binsrv/connection_config.cpp
@@ -3,6 +3,7 @@
 #include <charconv>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <stdexcept>
 
 #include <boost/json/src.hpp>
@@ -20,36 +21,42 @@ constexpr std::string_view key_password{"password"};
 
 namespace binsrv {
 
-connection_config::connection_config(const parameter_container &parameters)
-    : host_{parameters[0]}, port_{0}, user_{parameters[2]},
-      password_{parameters[3]} {
-  auto port_bg = parameters[1].data();
-  auto port_en = port_bg + parameters[1].size();
+connection_config::connection_config(util::command_line_arg_view arguments)
+    : host_{arguments[1]}, port_{0}, user_{arguments[3]},
+      password_{arguments[4]} {
+  const auto *port_bg = arguments[2];
+  const auto *port_en = std::next(
+      port_bg, static_cast<std::ptrdiff_t>(std::strlen(arguments[2])));
   auto [ptr, ec] = std::from_chars(port_bg, port_en, port_);
-  if (ec != std::errc() || ptr != port_en)
+  if (ec != std::errc() || ptr != port_en) {
     util::raise_exception<std::invalid_argument>("invalid port value");
+  }
 }
 
 connection_config::connection_config(std::string_view file_name)
     : host_{}, port_{0}, user_{}, password_{} {
   static constexpr std::size_t max_file_size = 1048576;
 
-  std::filesystem::path file_path{file_name};
+  const std::filesystem::path file_path{file_name};
   std::ifstream ifs{file_path};
-  if (!ifs.is_open())
+  if (!ifs.is_open()) {
     util::raise_exception<std::invalid_argument>(
         "cannot open configuration file");
+  }
   auto file_size = std::filesystem::file_size(file_path);
-  if (file_size == 0)
+  if (file_size == 0) {
     util::raise_exception<std::invalid_argument>("configuration file is empty");
-  if (file_size > max_file_size)
+  }
+  if (file_size > max_file_size) {
     util::raise_exception<std::invalid_argument>(
         "configuration file is too large");
+  }
 
   std::string file_content(file_size, 'x');
-  if (!ifs.read(file_content.data(), static_cast<std::streamoff>(file_size)))
+  if (!ifs.read(file_content.data(), static_cast<std::streamoff>(file_size))) {
     util::raise_exception<std::invalid_argument>(
         "cannot read configuration file content");
+  }
 
   try {
     auto json_value = boost::json::parse(file_content);

--- a/src/binsrv/connection_config.hpp
+++ b/src/binsrv/connection_config.hpp
@@ -1,29 +1,31 @@
 #ifndef BINSRV_CONNECTION_CONFIG_HPP
 #define BINSRV_CONNECTION_CONFIG_HPP
 
-#include <array>
+#include "binsrv/connection_config_fwd.hpp"
+
 #include <cstdint>
 #include <string>
 #include <string_view>
+
+#include "util/command_line_helpers_fwd.hpp"
 
 namespace binsrv {
 
 class connection_config {
 public:
-  static constexpr std::size_t expected_number_of_parameters = 4;
-  using parameter_container =
-      std::array<std::string_view, expected_number_of_parameters>;
+  static constexpr std::size_t expected_number_of_arguments = 4;
 
-public:
+  // NOLINTBEGIN(bugprone-easily-swappable-parameters)
   [[nodiscard]] connection_config(std::string_view host, std::uint16_t port,
                                   std::string_view user,
                                   std::string_view password)
       : host_{host}, port_{port}, user_{user}, password_{password} {}
+  // NOLINTEND(bugprone-easily-swappable-parameters)
 
   [[nodiscard]] explicit connection_config(std::string_view file_name);
 
   [[nodiscard]] explicit connection_config(
-      const parameter_container &parameters);
+      util::command_line_arg_view arguments);
 
   [[nodiscard]] const std::string &get_host() const noexcept { return host_; }
   [[nodiscard]] std::uint16_t get_port() const noexcept { return port_; }

--- a/src/binsrv/connection_config_fwd.hpp
+++ b/src/binsrv/connection_config_fwd.hpp
@@ -1,0 +1,14 @@
+#ifndef BINSRV_CONNECTION_CONFIG_FWD_HPP
+#define BINSRV_CONNECTION_CONFIG_FWD_HPP
+
+#include <memory>
+
+namespace binsrv {
+
+class connection_config;
+
+using connection_config_ptr = std::shared_ptr<connection_config>;
+
+} // namespace binsrv
+
+#endif // BINSRV_CONNECTION_CONFIG_FWD_HPP

--- a/src/binsrv/ostream_logger.cpp
+++ b/src/binsrv/ostream_logger.cpp
@@ -1,0 +1,10 @@
+#include "binsrv/ostream_logger.hpp"
+
+namespace binsrv {
+
+void ostream_logger::do_log(std::string_view message) {
+  // flushing here deliberately
+  (*stream_) << message << std::endl;
+}
+
+} // namespace binsrv

--- a/src/binsrv/ostream_logger.hpp
+++ b/src/binsrv/ostream_logger.hpp
@@ -1,0 +1,23 @@
+#ifndef BINSRV_OSTREAM_LOGGER_HPP
+#define BINSRV_OSTREAM_LOGGER_HPP
+
+#include <ostream>
+
+#include "binsrv/basic_logger.hpp"
+
+namespace binsrv {
+
+class ostream_logger : public basic_logger {
+public:
+  explicit ostream_logger(std::ostream &stream)
+      : basic_logger{}, stream_{&stream} {}
+
+private:
+  std::ostream *stream_;
+
+  void do_log(std::string_view message) override;
+};
+
+} // namespace binsrv
+
+#endif // BINSRV_OSTREAM_LOGGER_HPP

--- a/src/util/command_line_helpers.cpp
+++ b/src/util/command_line_helpers.cpp
@@ -1,0 +1,23 @@
+#include "util/command_line_helpers.hpp"
+
+#include <filesystem>
+#include <string>
+
+namespace util {
+
+std::string extract_executable_name(util::command_line_arg_view cmd_args) {
+  std::string res;
+  if (!cmd_args.empty()) {
+    try {
+      const std::filesystem::path executable_path{cmd_args[0]};
+      auto filename = executable_path.filename();
+    } catch (const std::exception &) {
+    }
+  }
+  if (res.empty()) {
+    res = "executable";
+  }
+  return res;
+}
+
+} // namespace util

--- a/src/util/command_line_helpers.hpp
+++ b/src/util/command_line_helpers.hpp
@@ -1,0 +1,25 @@
+#ifndef UTIL_COMMAND_LINE_HELPERS_HPP
+#define UTIL_COMMAND_LINE_HELPERS_HPP
+
+#include <iterator>
+
+#include "util/command_line_helpers_fwd.hpp"
+
+namespace util {
+
+using command_line_arg_view = std::span<const char *const>;
+
+inline command_line_arg_view to_command_line_agg_view(
+    int argc,
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+    char *argv[]) noexcept {
+  const char *const *const const_argv = argv;
+  return {const_argv, static_cast<std::size_t>(argc)};
+}
+
+[[nodiscard]] std::string
+extract_executable_name(util::command_line_arg_view cmd_args);
+
+} // namespace util
+
+#endif // UTIL_COMMAND_LINE_HELPERS_HPP

--- a/src/util/command_line_helpers_fwd.hpp
+++ b/src/util/command_line_helpers_fwd.hpp
@@ -1,0 +1,12 @@
+#ifndef UTIL_COMMAND_LINE_HELPERS_FWD_HPP
+#define UTIL_COMMAND_LINE_HELPERS_FWD_HPP
+
+#include <span>
+
+namespace util {
+
+using command_line_arg_view = std::span<const char *const>;
+
+} // namespace util
+
+#endif // UTIL_COMMAND_LINE_HELPERS_FWD_HPP


### PR DESCRIPTION
Messages can be logged with different severity level (trace, debug, info, warning, error, and fatal). Logger itself can be configured with the minimum severity which allows basic filtering. All the messages are prepended with microsecond presicion timestamp.

Implemented one concrete ostream_logger class derived from basic_logger that can be used to output info into any user-created std::ostream (or into std::cout in particular).

Main application now creates an instance of a logger, prints readable MySQL client version and connection string.

Introduced command_line_helpers.hpp utility include file with convenience converters from (argc, argv).

One of the connection_config constructors can now accept wrapped command line arguments (created from (argc, argv) pair).