### PR TITLE
Implemented basic remote binlog stream reading

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: "
   *,
+  -altera-*
   -fuchsia-*,
   -android-*,
   -google-*,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ target_compile_options(binlog_server_compiler_flags INTERFACE
 find_package(Boost 1.81.0 EXACT REQUIRED)
 
 find_package(MySQL REQUIRED)
+find_package(OpenSSL REQUIRED)
+find_package(zstd REQUIRED)
+find_package(ZLIB REQUIRED)
 
 set(source_files
   src/app.cpp
@@ -31,6 +34,9 @@ set(source_files
   src/binsrv/basic_logger_fwd.hpp
   src/binsrv/basic_logger.hpp
   src/binsrv/basic_logger.cpp
+
+  src/binsrv/exception_handling_helpers.hpp
+  src/binsrv/exception_handling_helpers.cpp
 
   src/binsrv/ostream_logger.hpp
   src/binsrv/ostream_logger.cpp
@@ -42,6 +48,13 @@ set(source_files
   src/util/conversion_helpers.hpp
 
   src/util/exception_helpers.hpp
+
+  src/easymysql/core_error.hpp
+  src/easymysql/core_error.cpp
+
+  src/easymysql/binlog_fwd.hpp
+  src/easymysql/binlog.hpp
+  src/easymysql/binlog.cpp
 
   src/easymysql/connection_fwd.hpp
   src/easymysql/connection.hpp
@@ -57,7 +70,12 @@ set(source_files
 )
 
 add_executable(binlog_server ${source_files})
-target_link_libraries(binlog_server PUBLIC binlog_server_compiler_flags PRIVATE Boost::headers MySQL::client)
+target_link_libraries(binlog_server
+  PUBLIC
+     binlog_server_compiler_flags
+  PRIVATE
+    Boost::headers MySQL::client OpenSSL::Crypto OpenSSL::SSL zstd::libzstd_shared ZLIB::ZLIB
+)
 # for some reason it is not possible to propagate CXX_EXTENSIONS and
 # CXX_STANDARD_REQUIRED via interface library (binlog_server_compiler_flags)
 set_target_properties(binlog_server PROPERTIES

--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -84,7 +84,7 @@ if (MSVC)
                      ${libsuffixBuild}
     )
 else()
-    find_library(MYSQL_LIBRARY NAMES mysqlclient mysqlclient_r mariadbclient
+    find_library(MYSQL_LIBRARY NAMES libmysqlclient.a mysqlclient mysqlclient_r mariadbclient
                  HINTS
                     ${MYSQL_ROOT_DIR}/lib
                     ${MYSQL_ROOT_LIBRARY_DIRS}

--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -1,0 +1,67 @@
+#https://github.com/llvm/llvm-project/blob/main/llvm/cmake/modules/Findzstd.cmake
+
+# Try to find the zstd library
+#
+# If successful, the following variables will be defined:
+# zstd_INCLUDE_DIR
+# zstd_LIBRARY
+# zstd_STATIC_LIBRARY
+# zstd_FOUND
+#
+# Additionally, one of the following import targets will be defined:
+# zstd::libzstd_shared
+# zstd::libzstd_static
+
+if(MSVC)
+  set(zstd_STATIC_LIBRARY_SUFFIX "_static\\${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+else()
+  set(zstd_STATIC_LIBRARY_SUFFIX "\\${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+endif()
+
+find_path(zstd_INCLUDE_DIR NAMES zstd.h)
+find_library(zstd_LIBRARY NAMES zstd zstd_static)
+find_library(zstd_STATIC_LIBRARY NAMES
+  zstd_static
+  "${CMAKE_STATIC_LIBRARY_PREFIX}zstd${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    zstd DEFAULT_MSG
+    zstd_LIBRARY zstd_INCLUDE_DIR
+)
+
+if(zstd_FOUND)
+  if(zstd_LIBRARY MATCHES "${zstd_STATIC_LIBRARY_SUFFIX}$")
+    set(zstd_STATIC_LIBRARY "${zstd_LIBRARY}")
+  elseif (NOT TARGET zstd::libzstd_shared)
+    add_library(zstd::libzstd_shared SHARED IMPORTED)
+    if(MSVC)
+      # IMPORTED_LOCATION is the path to the DLL and IMPORTED_IMPLIB is the "library".
+      get_filename_component(zstd_DIRNAME "${zstd_LIBRARY}" DIRECTORY)
+      string(REGEX REPLACE "${CMAKE_INSTALL_LIBDIR}$" "${CMAKE_INSTALL_BINDIR}" zstd_DIRNAME "${zstd_DIRNAME}")
+      get_filename_component(zstd_BASENAME "${zstd_LIBRARY}" NAME)
+      string(REGEX REPLACE "\\${CMAKE_LINK_LIBRARY_SUFFIX}$" "${CMAKE_SHARED_LIBRARY_SUFFIX}" zstd_BASENAME "${zstd_BASENAME}")
+      set_target_properties(zstd::libzstd_shared PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${zstd_INCLUDE_DIR}"
+          IMPORTED_LOCATION "${zstd_DIRNAME}/${zstd_BASENAME}"
+          IMPORTED_IMPLIB "${zstd_LIBRARY}")
+      unset(zstd_DIRNAME)
+      unset(zstd_BASENAME)
+    else()
+      set_target_properties(zstd::libzstd_shared PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${zstd_INCLUDE_DIR}"
+          IMPORTED_LOCATION "${zstd_LIBRARY}")
+    endif()
+  endif()
+  if(zstd_STATIC_LIBRARY MATCHES "${zstd_STATIC_LIBRARY_SUFFIX}$" AND
+     NOT TARGET zstd::libzstd_static)
+    add_library(zstd::libzstd_static STATIC IMPORTED)
+    set_target_properties(zstd::libzstd_static PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${zstd_INCLUDE_DIR}"
+        IMPORTED_LOCATION "${zstd_STATIC_LIBRARY}")
+  endif()
+endif()
+
+unset(zstd_STATIC_LIBRARY_SUFFIX)
+
+mark_as_advanced(zstd_INCLUDE_DIR zstd_LIBRARY zstd_STATIC_LIBRARY)

--- a/src/binsrv/exception_handling_helpers.cpp
+++ b/src/binsrv/exception_handling_helpers.cpp
@@ -1,0 +1,57 @@
+#include "binsrv/exception_handling_helpers.hpp"
+
+#include <cassert>
+#include <memory>
+#include <source_location>
+#include <string>
+#include <system_error>
+
+#include <boost/lexical_cast.hpp>
+
+#include "binsrv/basic_logger.hpp"
+
+namespace {
+
+void handle_location_mixin(const binsrv::basic_logger_ptr &logger,
+                           const std::exception &wrapped_exception) {
+  assert(logger);
+  using namespace std::string_literals;
+  const auto *mixin = dynamic_cast<const std::source_location *>(
+      std::addressof(wrapped_exception));
+  if (mixin == nullptr) {
+    return;
+  }
+  logger->log(binsrv::log_severity::debug, "in "s + mixin->function_name());
+  // TODO: consider removing a few levels from the mixin->file_name() to
+  // avoid printing "/home/<user>/..." prefixes
+  logger->log(binsrv::log_severity::trace, "at "s + mixin->file_name() + ':' +
+                                               std::to_string(mixin->line()) +
+                                               ':' +
+                                               std::to_string(mixin->column()));
+}
+
+} // anonymous namespace
+
+namespace binsrv {
+
+void handle_std_exception(const basic_logger_ptr &logger) {
+  using namespace std::string_literals;
+  if (!logger) {
+    return;
+  }
+  try {
+    throw;
+  } catch (const std::system_error &e) {
+    logger->log(log_severity::error, "std::system_error caught: "s + e.what());
+    logger->log(log_severity::debug,
+                boost::lexical_cast<std::string>(e.code()));
+    handle_location_mixin(logger, e);
+  } catch (const std::exception &e) {
+    logger->log(log_severity::error, "std::exception caught: "s + e.what());
+    handle_location_mixin(logger, e);
+  } catch (...) {
+    logger->log(log_severity::info, "unhandled exception caught");
+  }
+}
+
+} // namespace binsrv

--- a/src/binsrv/exception_handling_helpers.hpp
+++ b/src/binsrv/exception_handling_helpers.hpp
@@ -1,0 +1,12 @@
+#ifndef BINSRV_EXCEPTION_HANDLING_HELPERS_HPP
+#define BINSRV_EXCEPTION_HANDLING_HELPERS_HPP
+
+#include "binsrv/basic_logger_fwd.hpp"
+
+namespace binsrv {
+
+void handle_std_exception(const basic_logger_ptr &logger);
+
+} // namespace binsrv
+
+#endif // BINSRV_EXCEPTION_HANDLING_HELPERS_HPP

--- a/src/easymysql/binlog.cpp
+++ b/src/easymysql/binlog.cpp
@@ -1,0 +1,82 @@
+#include "easymysql/binlog.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+
+#include <mysql/mysql.h>
+
+#include "easymysql/connection.hpp"
+#include "easymysql/core_error.hpp"
+
+#include "util/exception_helpers.hpp"
+
+namespace {
+
+constexpr std::uint64_t magic_binlog_offset = 4ULL;
+
+} // anonymous namespace
+
+namespace easymysql {
+
+void binlog::rpl_deleter::operator()(void *ptr) const noexcept {
+  if (ptr != nullptr) {
+    // deleting via std::default_delete to avoid
+    // cppcoreguidelines-owning-memory warnings
+    using delete_helper = std::default_delete<MYSQL_RPL>;
+    delete_helper{}(static_cast<MYSQL_RPL *>(ptr));
+  }
+}
+
+binlog::binlog(connection &conn, std::uint32_t server_id)
+    : conn_{&conn}, impl_{new MYSQL_RPL{.file_name_length = 0,
+                                        .file_name = nullptr,
+                                        .start_position = magic_binlog_offset,
+                                        .server_id = server_id,
+                                        .flags = 0,
+                                        .gtid_set_encoded_size = 0,
+                                        .fix_gtid_set = nullptr,
+                                        .gtid_set_arg = nullptr,
+                                        .size = 0,
+                                        .buffer = nullptr
+
+                    }} {
+  assert(!conn.is_empty());
+
+  static constexpr std::string_view crc_query{
+      "SET @source_binlog_checksum = 'NONE', "
+      "@master_binlog_checksum = 'NONE'"};
+  conn_->execute_generic_query_noresult(crc_query);
+
+  auto *casted_conn_impl = static_cast<MYSQL *>(conn.impl_.get());
+  if (mysql_binlog_open(casted_conn_impl,
+                        static_cast<MYSQL_RPL *>(impl_.get())) != 0) {
+    util::exception_location().raise<core_error>(
+        static_cast<int>(mysql_errno(casted_conn_impl)),
+        mysql_error(casted_conn_impl));
+  }
+}
+
+binlog::~binlog() {
+  if (conn_ != nullptr) {
+    assert(!conn_->is_empty());
+    assert(!is_empty());
+    mysql_binlog_close(static_cast<MYSQL *>(conn_->impl_.get()),
+                       static_cast<MYSQL_RPL *>(impl_.get()));
+  }
+}
+
+binlog_stream_span binlog::fetch() {
+  assert(conn_ != nullptr);
+  assert(!is_empty());
+  auto *casted_conn_impl = static_cast<MYSQL *>(conn_->impl_.get());
+  auto *casted_rpl_impl = static_cast<MYSQL_RPL *>(impl_.get());
+  if (mysql_binlog_fetch(casted_conn_impl, casted_rpl_impl) != 0) {
+    util::exception_location().raise<core_error>(
+        static_cast<int>(mysql_errno(casted_conn_impl)),
+        mysql_error(casted_conn_impl));
+  }
+  return {casted_rpl_impl->buffer, casted_rpl_impl->size};
+}
+
+} // namespace easymysql

--- a/src/easymysql/binlog.hpp
+++ b/src/easymysql/binlog.hpp
@@ -1,0 +1,46 @@
+#ifndef EASYMYSQL_BINLOG_HPP
+#define EASYMYSQL_BINLOG_HPP
+
+#include "easymysql/binlog_fwd.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <span>
+
+#include "easymysql/connection_fwd.hpp"
+
+namespace easymysql {
+
+class [[nodiscard]] binlog {
+  friend class connection;
+
+public:
+  binlog() = default;
+
+  binlog(const binlog &) = delete;
+  binlog(binlog &&) = default;
+  binlog &operator=(const binlog &) = delete;
+  binlog &operator=(binlog &&) = default;
+
+  ~binlog();
+
+  [[nodiscard]] bool is_empty() const noexcept { return !impl_; }
+
+  // returns empty span on EOF
+  // throws an exception on error
+  binlog_stream_span fetch();
+
+private:
+  binlog(connection &conn, std::uint32_t server_id);
+
+  connection *conn_{nullptr};
+  struct rpl_deleter {
+    void operator()(void *ptr) const noexcept;
+  };
+  using impl_ptr = std::unique_ptr<void, rpl_deleter>;
+  impl_ptr impl_;
+};
+
+} // namespace easymysql
+
+#endif // EASYMYSQL_BINLOG_HPP

--- a/src/easymysql/binlog_fwd.hpp
+++ b/src/easymysql/binlog_fwd.hpp
@@ -1,0 +1,14 @@
+#ifndef EASYMYSQL_BINLOG_FWD_HPP
+#define EASYMYSQL_BINLOG_FWD_HPP
+
+#include <span>
+
+namespace easymysql {
+
+class binlog;
+
+using binlog_stream_span = std::span<const unsigned char>;
+
+} // namespace easymysql
+
+#endif // EASYMYSQL_BINLOG_FWD_HPP

--- a/src/easymysql/connection.hpp
+++ b/src/easymysql/connection.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string_view>
 
+#include "easymysql/binlog_fwd.hpp"
 #include "easymysql/connection_config_fwd.hpp"
 #include "easymysql/library_fwd.hpp"
 
@@ -13,6 +14,7 @@ namespace easymysql {
 
 class [[nodiscard]] connection {
   friend class library;
+  friend class binlog;
 
 public:
   connection() = default;
@@ -33,6 +35,9 @@ public:
 
   [[nodiscard]] std::string_view get_server_connection_info() const noexcept;
   [[nodiscard]] std::string_view get_character_set_name() const noexcept;
+
+  [[nodiscard]] binlog create_binlog(std::uint32_t server_id);
+  void execute_generic_query_noresult(std::string_view query);
 
 private:
   explicit connection(const connection_config &config);

--- a/src/easymysql/connection_config.cpp
+++ b/src/easymysql/connection_config.cpp
@@ -29,7 +29,8 @@ connection_config::connection_config(util::command_line_arg_view arguments)
       port_bg, static_cast<std::ptrdiff_t>(std::strlen(arguments[2])));
   auto [ptr, ec] = std::from_chars(port_bg, port_en, port_);
   if (ec != std::errc() || ptr != port_en) {
-    util::raise_exception<std::invalid_argument>("invalid port value");
+    util::exception_location().raise<std::invalid_argument>(
+        "invalid port value");
   }
 }
 
@@ -40,21 +41,22 @@ connection_config::connection_config(std::string_view file_name)
   const std::filesystem::path file_path{file_name};
   std::ifstream ifs{file_path};
   if (!ifs.is_open()) {
-    util::raise_exception<std::invalid_argument>(
+    util::exception_location().raise<std::invalid_argument>(
         "cannot open configuration file");
   }
   auto file_size = std::filesystem::file_size(file_path);
   if (file_size == 0) {
-    util::raise_exception<std::invalid_argument>("configuration file is empty");
+    util::exception_location().raise<std::invalid_argument>(
+        "configuration file is empty");
   }
   if (file_size > max_file_size) {
-    util::raise_exception<std::invalid_argument>(
+    util::exception_location().raise<std::invalid_argument>(
         "configuration file is too large");
   }
 
   std::string file_content(file_size, 'x');
   if (!ifs.read(file_content.data(), static_cast<std::streamoff>(file_size))) {
-    util::raise_exception<std::invalid_argument>(
+    util::exception_location().raise<std::invalid_argument>(
         "cannot read configuration file content");
   }
 
@@ -69,7 +71,7 @@ connection_config::connection_config(std::string_view file_name)
         json_object.at(key_password));
 
   } catch (const std::exception &) {
-    util::raise_exception<std::invalid_argument>(
+    util::exception_location().raise<std::invalid_argument>(
         "cannot parse JSON configuration file");
   }
 }

--- a/src/easymysql/core_error.cpp
+++ b/src/easymysql/core_error.cpp
@@ -1,0 +1,31 @@
+#include "easymysql/core_error.hpp"
+
+#include <string>
+
+namespace easymysql {
+
+const std::error_category &mysql_category() noexcept {
+  class [[nodiscard]] category_impl : public std::error_category {
+  public:
+    [[nodiscard]] const char *name() const noexcept override {
+      return "mysql_client";
+    }
+    [[nodiscard]] std::string message(int code) const override {
+      // We cannot use ER_CLIENT() function here as
+      // it will return message strings with printf '%' parameters
+      return "CR_" + std::to_string(code);
+    }
+  };
+
+  static const category_impl instance;
+  return instance;
+}
+
+core_error::core_error(int native_error_code)
+    : std::system_error{make_mysql_error_code(native_error_code)} {}
+core_error::core_error(int native_error_code, const std::string &what)
+    : std::system_error{make_mysql_error_code(native_error_code), what} {}
+core_error::core_error(int native_error_code, const char *what)
+    : std::system_error{make_mysql_error_code(native_error_code), what} {}
+
+} // namespace easymysql

--- a/src/easymysql/core_error.hpp
+++ b/src/easymysql/core_error.hpp
@@ -1,0 +1,25 @@
+#ifndef EASYMYSQL_CORE_ERROR_HPP
+#define EASYMYSQL_CORE_ERROR_HPP
+
+#include <stdexcept>
+#include <system_error>
+
+namespace easymysql {
+
+[[nodiscard]] const std::error_category &mysql_category() noexcept;
+
+[[nodiscard]] inline std::error_code
+make_mysql_error_code(int native_error_code) noexcept {
+  return {native_error_code, mysql_category()};
+}
+
+class [[nodiscard]] core_error : public std::system_error {
+public:
+  explicit core_error(int native_error_code);
+  core_error(int native_error_code, const std::string &what);
+  core_error(int native_error_code, const char *what);
+};
+
+} // namespace easymysql
+
+#endif // EASYMYSQL_CORE_ERROR_HPP

--- a/src/easymysql/library.cpp
+++ b/src/easymysql/library.cpp
@@ -11,7 +11,8 @@ namespace easymysql {
 
 library::library() {
   if (mysql_library_init(0, nullptr, nullptr) != 0) {
-    util::raise_exception<std::logic_error>("cannot initialize MySQL livrary");
+    util::exception_location().raise<std::logic_error>(
+        "cannot initialize MySQL library");
   }
 }
 
@@ -29,7 +30,7 @@ std::string_view library::get_readable_client_version() const noexcept {
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-connection library::create_connection(const connection_config &config) {
+connection library::create_connection(const connection_config &config) const {
   return connection(config);
 }
 

--- a/src/easymysql/library.hpp
+++ b/src/easymysql/library.hpp
@@ -24,7 +24,8 @@ public:
   [[nodiscard]] std::uint32_t get_client_version() const noexcept;
   [[nodiscard]] std::string_view get_readable_client_version() const noexcept;
 
-  [[nodiscard]] connection create_connection(const connection_config &config);
+  [[nodiscard]] connection
+  create_connection(const connection_config &config) const;
 };
 
 } // namespace easymysql

--- a/src/util/command_line_helpers.hpp
+++ b/src/util/command_line_helpers.hpp
@@ -1,13 +1,11 @@
 #ifndef UTIL_COMMAND_LINE_HELPERS_HPP
 #define UTIL_COMMAND_LINE_HELPERS_HPP
 
-#include <iterator>
-
 #include "util/command_line_helpers_fwd.hpp"
 
-namespace util {
+#include <iterator>
 
-using command_line_arg_view = std::span<const char *const>;
+namespace util {
 
 inline command_line_arg_view to_command_line_agg_view(
     int argc,

--- a/src/util/exception_helpers.hpp
+++ b/src/util/exception_helpers.hpp
@@ -1,21 +1,50 @@
 #ifndef UTIL_EXCEPTION_HELPERS_HPP
 #define UTIL_EXCEPTION_HELPERS_HPP
 
+#include <concepts>
+#include <exception>
 #include <source_location>
 #include <string>
 #include <string_view>
 
 namespace util {
 
-template <typename T>
-[[noreturn]] void raise_exception(
-    std::string_view message,
-    const std::source_location &location = std::source_location::current()) {
-  std::string full_message{location.function_name()};
-  full_message += ": ";
-  full_message += message;
-  throw T{full_message};
-}
+template <std::derived_from<std::exception> Exception>
+class location_exception_adapter : public Exception,
+                                   public std::source_location {
+public:
+  using base_type = Exception;
+  using mixin_type = std::source_location;
+
+  template <typename... TT>
+  explicit location_exception_adapter(std::source_location location,
+                                      TT &&...args)
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+      : base_type{std::forward<TT>(args)...}, mixin_type{location} {}
+
+  [[nodiscard]] std::source_location get_location() const noexcept {
+    return *static_cast<const mixin_type *>(this);
+  }
+};
+
+// deliberately without [[nodiscard]] as this class is supposed to be used
+// as a helper only
+// e.g. exception_location().raise<std::invalid_argument>(
+//   "value cannot be zero")
+class exception_location {
+public:
+  explicit exception_location(
+      std::source_location location = std::source_location::current())
+      : location_{location} {}
+  template <std::derived_from<std::exception> Exception, typename... TT>
+  [[noreturn]] void raise(TT &&...args) const {
+    using wrapped_exception = location_exception_adapter<Exception>;
+    throw wrapped_exception{location_, std::forward<TT>(args)...};
+  }
+
+private:
+  std::source_location location_;
+};
 
 } // namespace util
 


### PR DESCRIPTION
Implemented new "easymysql::binlog" class which can be used to fetch data from the remote binlog stream.

Implemented new "easymysql::binlog" class which can be used to fetch
data from the remote binlog stream.

Introduced new mechanism for throwing / catching exceptions with
embedded "std::source_location"
"util::exception_location().raise<exception_class>()".

"easymysql::connection" class extended with ability to execute generic
SQL queries that do not produce results.
"easymysql::connection" class extended with ability to create instances
of the "easymysql::binlog" classes.

Introduced "easymysql::core_error" exception class derived from
"std::system_error" that is expected to be used for propagaring MySQL
client errors. Instances of this exception include "mysql_errno()"
codes.

Main applicatiom exception handling logic extracted into a separate
function "binsrv::handle_std_exception()".

Disabled irrelevant 'altera-*' clang-tidy checks.

Due to the bug in the libmysqlclient.so shared library that do not have
"mysql_binlog_xxx" symbols exported, now we link a static version of the
"mysqlclient" library - "libmysqlclient.a".

"OpenSSL", "zstd" and "zlib" are now also added as dependencies.
 Added "Findzstd.cmake" CMake module - imported from the LLVM
 repository.