### PR TITLE
Introduced deimpl helper class template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,13 +49,19 @@ set(source_files
 
   src/util/exception_helpers.hpp
 
+  src/util/impl_helpers.hpp
+
+  src/easymysql/core_error_helpers_private.hpp
+  src/easymysql/core_error_helpers_private.cpp
   src/easymysql/core_error.hpp
   src/easymysql/core_error.cpp
 
+  src/easymysql/binlog_deimpl_private.hpp
   src/easymysql/binlog_fwd.hpp
   src/easymysql/binlog.hpp
   src/easymysql/binlog.cpp
 
+  src/easymysql/connection_deimpl_private.hpp
   src/easymysql/connection_fwd.hpp
   src/easymysql/connection.hpp
   src/easymysql/connection.cpp

--- a/src/easymysql/binlog_deimpl_private.hpp
+++ b/src/easymysql/binlog_deimpl_private.hpp
@@ -1,0 +1,14 @@
+#ifndef EASYMYSQL_BINLOG_DEIMPL_PRIVATE_HPP
+#define EASYMYSQL_BINLOG_DEIMPL_PRIVATE_HPP
+
+#include <mysql/mysql.h>
+
+#include "util/impl_helpers.hpp"
+
+namespace easymysql {
+
+using binlog_deimpl = util::deimpl<MYSQL_RPL>;
+
+} // namespace easymysql
+
+#endif // EASYMYSQL_BINLOG_DEIMPL_PRIVATE_HPP

--- a/src/easymysql/connection.cpp
+++ b/src/easymysql/connection.cpp
@@ -7,7 +7,8 @@
 
 #include "easymysql/binlog.hpp"
 #include "easymysql/connection_config.hpp"
-#include "easymysql/core_error.hpp"
+#include "easymysql/connection_deimpl_private.hpp"
+#include "easymysql/core_error_helpers_private.hpp"
 
 #include "util/conversion_helpers.hpp"
 #include "util/exception_helpers.hpp"
@@ -26,7 +27,7 @@ connection::connection(const connection_config &config)
     util::exception_location().raise<std::logic_error>(
         "cannot create MYSQL object");
   }
-  auto *casted_impl = static_cast<MYSQL *>(impl_.get());
+  auto *casted_impl = connection_deimpl::get(impl_);
   if (mysql_real_connect(casted_impl,
                          /*        host */ config.get_host().c_str(),
                          /*        user */ config.get_user().c_str(),
@@ -35,48 +36,47 @@ connection::connection(const connection_config &config)
                          /*        port */ config.get_port(),
                          /* unix socket */ nullptr,
                          /*       flags */ 0) == nullptr) {
-    util::exception_location().raise<core_error>(
-        static_cast<int>(mysql_errno(casted_impl)), mysql_error(casted_impl));
+    raise_core_error_from_connection(*this);
   }
 }
 
 std::uint32_t connection::get_server_version() const noexcept {
   assert(!is_empty());
   return util::maybe_useless_integral_cast<std::uint32_t>(
-      mysql_get_server_version(static_cast<MYSQL *>(impl_.get())));
+      mysql_get_server_version(connection_deimpl::get_const_casted(impl_)));
 }
 
 std::string_view connection::get_readable_server_version() const noexcept {
   assert(!is_empty());
-  return {mysql_get_server_info(static_cast<MYSQL *>(impl_.get()))};
+  return {mysql_get_server_info(connection_deimpl::get_const_casted(impl_))};
 }
 
 std::uint32_t connection::get_protocol_version() const noexcept {
   assert(!is_empty());
   return util::maybe_useless_integral_cast<std::uint32_t>(
-      mysql_get_proto_info(static_cast<MYSQL *>(impl_.get())));
+      mysql_get_proto_info(connection_deimpl::get_const_casted(impl_)));
 }
 
 std::string_view connection::get_server_connection_info() const noexcept {
   assert(!is_empty());
-  return {mysql_get_host_info(static_cast<MYSQL *>(impl_.get()))};
+  return {mysql_get_host_info(connection_deimpl::get_const_casted(impl_))};
 }
 
 std::string_view connection::get_character_set_name() const noexcept {
   assert(!is_empty());
-  return {mysql_character_set_name(static_cast<MYSQL *>(impl_.get()))};
+  return {mysql_character_set_name(connection_deimpl::get_const_casted(impl_))};
 }
 
 binlog connection::create_binlog(std::uint32_t server_id) {
+  assert(!is_empty());
   return {*this, server_id};
 }
 
 void connection::execute_generic_query_noresult(std::string_view query) {
   assert(!is_empty());
-  auto *casted_impl = static_cast<MYSQL *>(impl_.get());
+  auto *casted_impl = connection_deimpl::get(impl_);
   if (mysql_real_query(casted_impl, query.data(), query.size()) != 0) {
-    util::exception_location().raise<core_error>(
-        static_cast<int>(mysql_errno(casted_impl)), mysql_error(casted_impl));
+    raise_core_error_from_connection(*this);
   }
 }
 

--- a/src/easymysql/connection.hpp
+++ b/src/easymysql/connection.hpp
@@ -15,6 +15,7 @@ namespace easymysql {
 class [[nodiscard]] connection {
   friend class library;
   friend class binlog;
+  friend struct raise_access;
 
 public:
   connection() = default;

--- a/src/easymysql/connection_deimpl_private.hpp
+++ b/src/easymysql/connection_deimpl_private.hpp
@@ -1,0 +1,14 @@
+#ifndef EASYMYSQL_CONNECTION_DEIMPL_PRIVATE_HPP
+#define EASYMYSQL_CONNECTION_DEIMPL_PRIVATE_HPP
+
+#include <mysql/mysql.h>
+
+#include "util/impl_helpers.hpp"
+
+namespace easymysql {
+
+using connection_deimpl = util::deimpl<MYSQL>;
+
+} // namespace easymysql
+
+#endif // EASYMYSQL_CONNECTION_DEIMPL_PRIVATE_HPP

--- a/src/easymysql/core_error_helpers_private.cpp
+++ b/src/easymysql/core_error_helpers_private.cpp
@@ -1,0 +1,35 @@
+#include "easymysql/core_error_helpers_private.hpp"
+
+#include <mysql/mysql.h>
+
+#include "easymysql/connection.hpp"
+#include "easymysql/connection_deimpl_private.hpp"
+#include "easymysql/core_error.hpp"
+
+#include "util/exception_helpers.hpp"
+
+namespace easymysql {
+
+struct raise_access {
+  static const connection::impl_ptr &get(const connection &conn) noexcept {
+    return conn.impl_;
+  }
+};
+
+[[noreturn]] void
+raise_core_error_from_connection(const connection &conn,
+                                 std::source_location location) {
+  // default value std::source_location::current() for the 'location'
+  // parameter is specified in the declaration of this function
+  // and passed to the util::exception_location's constructor
+  // instead of calling util::exception_location's default constructor
+  // because otherwise the location will always point to this
+  // particular line on this particular file regardless of the actual
+  // location from where this function is called
+  auto *casted_impl =
+      connection_deimpl::get_const_casted(raise_access::get(conn));
+  util::exception_location(location).raise<core_error>(
+      static_cast<int>(mysql_errno(casted_impl)), mysql_error(casted_impl));
+}
+
+} // namespace easymysql

--- a/src/easymysql/core_error_helpers_private.hpp
+++ b/src/easymysql/core_error_helpers_private.hpp
@@ -1,0 +1,15 @@
+#ifndef EASYMYSQL_CORE_ERROR_HELPERS_PRIVATE_HPP
+#define EASYMYSQL_CORE_ERROR_HELPERS_PRIVATE_HPP
+
+#include "easymysql/connection_fwd.hpp"
+#include <source_location>
+
+namespace easymysql {
+
+[[noreturn]] void raise_core_error_from_connection(
+    const connection &conn,
+    std::source_location location = std::source_location::current());
+
+} // namespace easymysql
+
+#endif // EASYMYSQL_CORE_ERROR_HELPERS_PRIVATE_HPP

--- a/src/util/exception_helpers.hpp
+++ b/src/util/exception_helpers.hpp
@@ -10,8 +10,8 @@
 namespace util {
 
 template <std::derived_from<std::exception> Exception>
-class location_exception_adapter : public Exception,
-                                   public std::source_location {
+class [[nodiscard]] location_exception_adapter : public Exception,
+                                                 public std::source_location {
 public:
   using base_type = Exception;
   using mixin_type = std::source_location;

--- a/src/util/impl_helpers.hpp
+++ b/src/util/impl_helpers.hpp
@@ -1,0 +1,30 @@
+#ifndef UTIL_IMPL_HELPERS_HPP
+#define UTIL_IMPL_HELPERS_HPP
+
+#include <memory>
+
+namespace util {
+
+template <typename T> struct deimpl {
+  template <typename Deleter>
+  [[nodiscard]] static T *get(std::unique_ptr<void, Deleter> &impl) noexcept {
+    return static_cast<T *>(impl.get());
+  }
+  template <typename Deleter>
+  [[nodiscard]] static const T *
+  get(const std::unique_ptr<void, Deleter> &impl) noexcept {
+    return static_cast<const T *>(impl.get());
+  }
+  // get_const_casted() is supposed to be used to fix broken
+  // legacy C interfaces without const quilifiers for read-only
+  // parameters
+  template <typename Deleter>
+  [[nodiscard]] static T *
+  get_const_casted(const std::unique_ptr<void, Deleter> &impl) noexcept {
+    return static_cast<T *>(impl.get());
+  }
+};
+
+} // namespace util
+
+#endif // UTIL_IMPL_HELPERS_HPP


### PR DESCRIPTION
This template helps to avoid ugly static_casts after extracting 'void *' pointers from the 'std::unique_ptr<void, deleter>' pimpl non-static members.

Introduced 'raise_core_error_from_connection()' helper function that raises 'easymysql::core_error' with error code and error message extracted from the MYSQL data structure via 'mysql_errno()' and 'mysql_error()'.