### PR TITLE
Added basic binlog event parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,19 @@ set(source_files
   src/binsrv/exception_handling_helpers.hpp
   src/binsrv/exception_handling_helpers.cpp
 
+  src/binsrv/event_flag_fwd.hpp
+  src/binsrv/event_flag.hpp
+
+  src/binsrv/event_header_fwd.hpp
+  src/binsrv/event_header.hpp
+  src/binsrv/event_header.cpp
+
+  src/binsrv/event_type_fwd.hpp
+  src/binsrv/event_type.hpp
+
+  src/binsrv/log_severity_fwd.hpp
+  src/binsrv/log_severity.hpp
+
   src/binsrv/ostream_logger.hpp
   src/binsrv/ostream_logger.cpp
 
@@ -48,6 +61,9 @@ set(source_files
   src/util/conversion_helpers.hpp
 
   src/util/exception_helpers.hpp
+
+  src/util/flag_set_fwd.hpp
+  src/util/flag_set.hpp
 
   src/util/impl_helpers.hpp
 

--- a/src/binsrv/basic_logger.cpp
+++ b/src/binsrv/basic_logger.cpp
@@ -7,7 +7,12 @@
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <boost/date_time/posix_time/time_formatters_limited.hpp>
 
+#include "binsrv/log_severity.hpp"
+
 namespace binsrv {
+
+basic_logger::basic_logger(log_severity min_level) noexcept
+    : min_level_{min_level} {}
 
 void basic_logger::log(log_severity level, std::string_view message) {
   if (level >= min_level_) {

--- a/src/binsrv/basic_logger.hpp
+++ b/src/binsrv/basic_logger.hpp
@@ -3,36 +3,11 @@
 
 #include "binsrv/basic_logger_fwd.hpp"
 
-#include <algorithm>
-#include <array>
 #include <string_view>
-#include <type_traits>
+
+#include "binsrv/log_severity_fwd.hpp"
 
 namespace binsrv {
-
-// NOLINTBEGIN(cppcoreguidelines-macro-usage)
-#define BINSRV_BASIC_LOGGER_X_SEQUENCE()                                       \
-  BINSRV_BASIC_LOGGER_X_MACRO(trace), BINSRV_BASIC_LOGGER_X_MACRO(debug),      \
-      BINSRV_BASIC_LOGGER_X_MACRO(info), BINSRV_BASIC_LOGGER_X_MACRO(warning), \
-      BINSRV_BASIC_LOGGER_X_MACRO(error), BINSRV_BASIC_LOGGER_X_MACRO(fatal)
-
-#define BINSRV_BASIC_LOGGER_X_MACRO(X) X
-enum class log_severity { BINSRV_BASIC_LOGGER_X_SEQUENCE(), delimiter };
-#undef BINSRV_BASIC_LOGGER_X_MACRO
-
-#define BINSRV_BASIC_LOGGER_X_MACRO(X) #X##sv
-inline std::string_view to_string_view(log_severity level) noexcept {
-  using namespace std::string_view_literals;
-  static constexpr std::array labels{BINSRV_BASIC_LOGGER_X_SEQUENCE(), ""sv};
-  const auto index = static_cast<std::size_t>(
-      static_cast<std::underlying_type_t<log_severity>>(
-          std::min(log_severity::delimiter, level)));
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-  return labels[index];
-}
-#undef BINSRV_BASIC_LOGGER_X_MACRO
-#undef BINSRV_BASIC_LOGGER_X_SEQUENCE
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 class [[nodiscard]] basic_logger {
 public:
@@ -53,10 +28,10 @@ public:
   void log(log_severity level, std::string_view message);
 
 protected:
-  basic_logger() = default;
+  explicit basic_logger(log_severity min_level) noexcept;
 
 private:
-  log_severity min_level_{log_severity::info};
+  log_severity min_level_;
 
   virtual void do_log(std::string_view message) = 0;
 };

--- a/src/binsrv/basic_logger_fwd.hpp
+++ b/src/binsrv/basic_logger_fwd.hpp
@@ -5,8 +5,6 @@
 
 namespace binsrv {
 
-enum class log_severity;
-
 class basic_logger;
 
 using basic_logger_ptr = std::shared_ptr<basic_logger>;

--- a/src/binsrv/event_flag.hpp
+++ b/src/binsrv/event_flag.hpp
@@ -1,0 +1,53 @@
+#ifndef BINSRV_EVENT_FLAG_HPP
+#define BINSRV_EVENT_FLAG_HPP
+
+#include "binsrv/event_flag_fwd.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <string_view>
+
+#include "util/flag_set.hpp"
+
+namespace binsrv {
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+// Event flags copied from
+// https://github.com/mysql/mysql-server/blob/mysql-8.0.33/sql/log_event.h#L253
+// clang-format off
+#define BINSRV_EVENT_FLAG_XY_SEQUENCE() \
+  BINSRV_EVENT_FLAG_XY_MACRO(thread_specific, 0x004U), \
+  BINSRV_EVENT_FLAG_XY_MACRO(suppress_use   , 0x008U), \
+  BINSRV_EVENT_FLAG_XY_MACRO(artificial     , 0x020U), \
+  BINSRV_EVENT_FLAG_XY_MACRO(relay_log      , 0x040U), \
+  BINSRV_EVENT_FLAG_XY_MACRO(ignorable      , 0x080U), \
+  BINSRV_EVENT_FLAG_XY_MACRO(no_filter      , 0x100U), \
+  BINSRV_EVENT_FLAG_XY_MACRO(mts_isolate    , 0x200U)
+// clang-format on
+
+#define BINSRV_EVENT_FLAG_XY_MACRO(X, Y) X = Y
+enum class event_flag : std::uint16_t {
+  BINSRV_EVENT_FLAG_XY_SEQUENCE(),
+  delimiter
+};
+#undef BINSRV_EVENT_FLAG_XY_MACRO
+
+inline std::string_view to_string_view(event_flag code) noexcept {
+  using namespace std::string_view_literals;
+  using nv_pair = std::pair<event_flag, std::string_view>;
+#define BINSRV_EVENT_FLAG_XY_MACRO(X, Y)                                       \
+  nv_pair { event_flag::X, #X##sv }
+  static constexpr std::array labels{BINSRV_EVENT_FLAG_XY_SEQUENCE(),
+                                     nv_pair{event_flag::delimiter, ""sv}};
+#undef BINSRV_EVENT_FLAG_XY_MACRO
+  return std::ranges::find(labels, std::min(event_flag::delimiter, code),
+                           &nv_pair::first)
+      ->second;
+}
+#undef BINSRV_EVENT_FLAG_XY_SEQUENCE
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+} // namespace binsrv
+
+#endif // BINSRV_EVENT_FLAG_HPP

--- a/src/binsrv/event_flag_fwd.hpp
+++ b/src/binsrv/event_flag_fwd.hpp
@@ -1,0 +1,16 @@
+#ifndef BINSRV_EVENT_FLAG_FWD_HPP
+#define BINSRV_EVENT_FLAG_FWD_HPP
+
+#include <cstdint>
+
+#include "util/flag_set_fwd.hpp"
+
+namespace binsrv {
+
+enum class event_flag : std::uint16_t;
+
+using event_flag_set = util::flag_set<event_flag>;
+
+} // namespace binsrv
+
+#endif // BINSRV_EVENT_FLAG_FWD_HPP

--- a/src/binsrv/event_header.cpp
+++ b/src/binsrv/event_header.cpp
@@ -1,0 +1,104 @@
+#include "binsrv/event_header.hpp"
+
+#include <cassert>
+#include <concepts>
+
+#include <boost/date_time/posix_time/conversion.hpp>
+#include <boost/date_time/posix_time/time_formatters.hpp>
+#include <boost/endian/conversion.hpp>
+
+#include "binsrv/event_flag.hpp"
+#include "binsrv/event_type.hpp"
+
+#include "util/exception_helpers.hpp"
+
+namespace {
+
+template <std::integral T>
+[[nodiscard]] inline T
+read_fixed_int_from_span(easymysql::binlog_stream_span portion) noexcept {
+  assert(std::size(portion) == sizeof(T));
+  T result;
+  std::memcpy(&result, std::data(portion), sizeof(T));
+  // A fixed-length unsigned integer stores its value in a series of
+  // bytes with the least significant byte first.
+  // TODO: in c++23 use std::byteswap()
+  return boost::endian::little_to_native(result);
+}
+
+template <std::integral T>
+bool extract_int_fixed_int_from_stream(easymysql::binlog_stream_span &remainder,
+                                       T &value) noexcept {
+  if (std::size(remainder) < sizeof(T)) {
+    return false;
+  }
+  value = read_fixed_int_from_span<T>(remainder.subspan(0, sizeof(T)));
+  remainder = remainder.subspan(sizeof(T));
+  return true;
+}
+
+} // anonymous namespace
+
+namespace binsrv {
+
+event_header::event_header(easymysql::binlog_stream_span portion) {
+  /*
+    https://github.com/mysql/mysql-server/blob/mysql-8.0.33/libbinlogevents/src/binlog_event.cpp#L197
+
+    The first 19 bytes in the header is as follows:
+      +============================================+
+      | member_variable               offset : len |
+      +============================================+
+      | when.tv_sec                        0 : 4   |
+      +--------------------------------------------+
+      | type_code       EVENT_TYPE_OFFSET(4) : 1   |
+      +--------------------------------------------+
+      | server_id       SERVER_ID_OFFSET(5)  : 4   |
+      +--------------------------------------------+
+      | data_written    EVENT_LEN_OFFSET(9)  : 4   |
+      +--------------------------------------------+
+      | log_pos           LOG_POS_OFFSET(13) : 4   |
+      +--------------------------------------------+
+      | flags               FLAGS_OFFSET(17) : 2   |
+      +--------------------------------------------+
+      | extra_headers                     19 : x-19|
+      +============================================+
+   */
+  auto remainder = portion;
+  auto result =
+      extract_int_fixed_int_from_stream(remainder, timestamp_) &&
+      extract_int_fixed_int_from_stream(remainder, type_code_) &&
+      extract_int_fixed_int_from_stream(remainder, server_id_) &&
+      extract_int_fixed_int_from_stream(remainder, event_size_) &&
+      extract_int_fixed_int_from_stream(remainder, next_event_position_) &&
+      extract_int_fixed_int_from_stream(remainder, flags_);
+  if (!result) {
+    util::exception_location().raise<std::invalid_argument>(
+        "invalid event header");
+  }
+  if (get_type_code_raw() >=
+      static_cast<std::underlying_type_t<event_type>>(event_type::delimiter)) {
+    util::exception_location().raise<std::invalid_argument>(
+        "invalid event header");
+  }
+}
+
+[[nodiscard]] std::string event_header::get_readable_timestamp() const {
+  return boost::posix_time::to_simple_string(
+      boost::posix_time::from_time_t(get_timestamp()));
+}
+
+[[nodiscard]] std::string_view
+event_header::get_readable_type_code() const noexcept {
+  return to_string_view(get_type_code());
+}
+
+[[nodiscard]] event_flag_set event_header::get_flags() const noexcept {
+  return event_flag_set{get_flags_raw()};
+}
+
+[[nodiscard]] std::string event_header::get_readable_flags() const {
+  return to_string(get_flags());
+}
+
+} // namespace binsrv

--- a/src/binsrv/event_header.hpp
+++ b/src/binsrv/event_header.hpp
@@ -1,0 +1,65 @@
+#ifndef BINSRV_EVENT_HEADER_HPP
+#define BINSRV_EVENT_HEADER_HPP
+
+#include "binsrv/event_header_fwd.hpp"
+
+#include <cstdint>
+#include <ctime>
+#include <string>
+#include <string_view>
+
+#include "binsrv/event_flag_fwd.hpp"
+#include "binsrv/event_type_fwd.hpp"
+#include "easymysql/binlog_fwd.hpp"
+
+namespace binsrv {
+
+class [[nodiscard]] event_header {
+public:
+  explicit event_header(easymysql::binlog_stream_span portion);
+
+  [[nodiscard]] std::uint32_t get_timestamp_raw() const noexcept {
+    return timestamp_;
+  }
+  [[nodiscard]] std::time_t get_timestamp() const noexcept {
+    return static_cast<std::time_t>(get_timestamp_raw());
+  }
+  [[nodiscard]] std::string get_readable_timestamp() const;
+
+  [[nodiscard]] std::uint8_t get_type_code_raw() const noexcept {
+    return type_code_;
+  }
+  [[nodiscard]] event_type get_type_code() const noexcept {
+    return static_cast<event_type>(get_type_code_raw());
+  }
+  [[nodiscard]] std::string_view get_readable_type_code() const noexcept;
+
+  [[nodiscard]] std::uint32_t get_server_id() const noexcept {
+    return server_id_;
+  }
+
+  [[nodiscard]] std::uint32_t get_event_size() const noexcept {
+    return event_size_;
+  }
+
+  [[nodiscard]] std::uint32_t get_next_event_position() const noexcept {
+    return next_event_position_;
+  }
+
+  [[nodiscard]] std::uint16_t get_flags_raw() const noexcept { return flags_; }
+  [[nodiscard]] event_flag_set get_flags() const noexcept;
+  [[nodiscard]] std::string get_readable_flags() const;
+
+private:
+  // the members are deliberately reordered for better packing
+  std::uint32_t timestamp_{};
+  std::uint32_t server_id_{};
+  std::uint32_t event_size_{};
+  std::uint32_t next_event_position_{};
+  std::uint16_t flags_{};
+  std::uint8_t type_code_{};
+};
+
+} // namespace binsrv
+
+#endif // BINSRV_EVENT_HEADER_HPP

--- a/src/binsrv/event_header_fwd.hpp
+++ b/src/binsrv/event_header_fwd.hpp
@@ -1,0 +1,10 @@
+#ifndef BINSRV_EVENT_HEADER_FWD_HPP
+#define BINSRV_EVENT_HEADER_FWD_HPP
+
+namespace binsrv {
+
+class event_header;
+
+} // namespace binsrv
+
+#endif // BINSRV_EVENT_HEADER_FWD_HPP

--- a/src/binsrv/event_type.hpp
+++ b/src/binsrv/event_type.hpp
@@ -1,0 +1,79 @@
+#ifndef BINSRV_EVENT_TYPE_HPP
+#define BINSRV_EVENT_TYPE_HPP
+
+#include "binsrv/event_type_fwd.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <string_view>
+
+namespace binsrv {
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+// Event type codes copied from
+// https://github.com/mysql/mysql-server/blob/mysql-8.0.33/libbinlogevents/include/binlog_event.h#L274
+// clang-format off
+#define BINSRV_EVENT_TYPE_XY_SEQUENCE() \
+  BINSRV_EVENT_TYPE_XY_MACRO(unknown            ,  0), \
+  BINSRV_EVENT_TYPE_XY_MACRO(start_v3           ,  1), \
+  BINSRV_EVENT_TYPE_XY_MACRO(query              ,  2), \
+  BINSRV_EVENT_TYPE_XY_MACRO(stop               ,  3), \
+  BINSRV_EVENT_TYPE_XY_MACRO(rotate             ,  4), \
+  BINSRV_EVENT_TYPE_XY_MACRO(intvar             ,  5), \
+  BINSRV_EVENT_TYPE_XY_MACRO(slave              ,  7), \
+  BINSRV_EVENT_TYPE_XY_MACRO(append_block       ,  9), \
+  BINSRV_EVENT_TYPE_XY_MACRO(delete_file        , 11), \
+  BINSRV_EVENT_TYPE_XY_MACRO(rand               , 13), \
+  BINSRV_EVENT_TYPE_XY_MACRO(user_var           , 14), \
+  BINSRV_EVENT_TYPE_XY_MACRO(format_description , 15), \
+  BINSRV_EVENT_TYPE_XY_MACRO(xid                , 16), \
+  BINSRV_EVENT_TYPE_XY_MACRO(begin_load_query   , 17), \
+  BINSRV_EVENT_TYPE_XY_MACRO(execute_load_query , 18), \
+  BINSRV_EVENT_TYPE_XY_MACRO(table_map          , 19), \
+  BINSRV_EVENT_TYPE_XY_MACRO(write_rows_v1      , 23), \
+  BINSRV_EVENT_TYPE_XY_MACRO(update_rows_v1     , 24), \
+  BINSRV_EVENT_TYPE_XY_MACRO(delete_rows_v1     , 25), \
+  BINSRV_EVENT_TYPE_XY_MACRO(incident           , 26), \
+  BINSRV_EVENT_TYPE_XY_MACRO(heartbeat_log      , 27), \
+  BINSRV_EVENT_TYPE_XY_MACRO(ignorable_log      , 28), \
+  BINSRV_EVENT_TYPE_XY_MACRO(rows_query_log     , 29), \
+  BINSRV_EVENT_TYPE_XY_MACRO(write_rows         , 30), \
+  BINSRV_EVENT_TYPE_XY_MACRO(update_rows        , 31), \
+  BINSRV_EVENT_TYPE_XY_MACRO(delete_rows        , 32), \
+  BINSRV_EVENT_TYPE_XY_MACRO(gtid_log           , 33), \
+  BINSRV_EVENT_TYPE_XY_MACRO(anonymous_gtid_log , 34), \
+  BINSRV_EVENT_TYPE_XY_MACRO(previous_gtids_log , 35), \
+  BINSRV_EVENT_TYPE_XY_MACRO(transaction_context, 36), \
+  BINSRV_EVENT_TYPE_XY_MACRO(view_change        , 37), \
+  BINSRV_EVENT_TYPE_XY_MACRO(xa_prepare_log     , 38), \
+  BINSRV_EVENT_TYPE_XY_MACRO(partial_update_rows, 39), \
+  BINSRV_EVENT_TYPE_XY_MACRO(transaction_payload, 40), \
+  BINSRV_EVENT_TYPE_XY_MACRO(heartbeat_log_v2   , 41)
+// clang-format on
+
+#define BINSRV_EVENT_TYPE_XY_MACRO(X, Y) X = Y
+enum class event_type : std::uint8_t {
+  BINSRV_EVENT_TYPE_XY_SEQUENCE(),
+  delimiter
+};
+#undef BINSRV_EVENT_TYPE_XY_MACRO
+
+inline std::string_view to_string_view(event_type code) noexcept {
+  using namespace std::string_view_literals;
+  using nv_pair = std::pair<event_type, std::string_view>;
+#define BINSRV_EVENT_TYPE_XY_MACRO(X, Y)                                       \
+  nv_pair { event_type::X, #X##sv }
+  static constexpr std::array labels{BINSRV_EVENT_TYPE_XY_SEQUENCE(),
+                                     nv_pair{event_type::delimiter, ""sv}};
+#undef BINSRV_EVENT_TYPE_XY_MACRO
+  return std::ranges::find(labels, std::min(event_type::delimiter, code),
+                           &nv_pair::first)
+      ->second;
+}
+#undef BINSRV_EVENT_TYPE_XY_SEQUENCE
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+} // namespace binsrv
+
+#endif // BINSRV_EVENT_TYPE_HPP

--- a/src/binsrv/event_type_fwd.hpp
+++ b/src/binsrv/event_type_fwd.hpp
@@ -1,0 +1,12 @@
+#ifndef BINSRV_EVENT_TYPE_FWD_HPP
+#define BINSRV_EVENT_TYPE_FWD_HPP
+
+#include <cstdint>
+
+namespace binsrv {
+
+enum class event_type : std::uint8_t;
+
+} // namespace binsrv
+
+#endif // BINSRV_EVENT_TYPE_FWD_HPP

--- a/src/binsrv/exception_handling_helpers.cpp
+++ b/src/binsrv/exception_handling_helpers.cpp
@@ -9,6 +9,7 @@
 #include <boost/lexical_cast.hpp>
 
 #include "binsrv/basic_logger.hpp"
+#include "binsrv/log_severity.hpp"
 
 namespace {
 
@@ -50,7 +51,7 @@ void handle_std_exception(const basic_logger_ptr &logger) {
     logger->log(log_severity::error, "std::exception caught: "s + e.what());
     handle_location_mixin(logger, e);
   } catch (...) {
-    logger->log(log_severity::info, "unhandled exception caught");
+    logger->log(log_severity::error, "unhandled exception caught");
   }
 }
 

--- a/src/binsrv/log_severity.hpp
+++ b/src/binsrv/log_severity.hpp
@@ -1,0 +1,47 @@
+#ifndef BINSRV_LOG_SEVERITY_HPP
+#define BINSRV_LOG_SEVERITY_HPP
+
+#include "binsrv/log_severity_fwd.hpp"
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+#include <type_traits>
+
+namespace binsrv {
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+// clang-format off
+#define BINSRV_LOG_SEVERITY_X_SEQUENCE() \
+  BINSRV_LOG_SEVERITY_X_MACRO(trace  ),  \
+  BINSRV_LOG_SEVERITY_X_MACRO(debug  ),  \
+  BINSRV_LOG_SEVERITY_X_MACRO(info   ),  \
+  BINSRV_LOG_SEVERITY_X_MACRO(warning),  \
+  BINSRV_LOG_SEVERITY_X_MACRO(error  ),  \
+  BINSRV_LOG_SEVERITY_X_MACRO(fatal  )
+// clang-format on
+
+#define BINSRV_LOG_SEVERITY_X_MACRO(X) X
+enum class log_severity : std::uint8_t {
+  BINSRV_LOG_SEVERITY_X_SEQUENCE(),
+  delimiter
+};
+#undef BINSRV_LOG_SEVERITY_X_MACRO
+
+inline std::string_view to_string_view(log_severity level) noexcept {
+  using namespace std::string_view_literals;
+#define BINSRV_LOG_SEVERITY_X_MACRO(X) #X##sv
+  static constexpr std::array labels{BINSRV_LOG_SEVERITY_X_SEQUENCE(), ""sv};
+#undef BINSRV_LOG_SEVERITY_X_MACRO
+  const auto index = static_cast<std::size_t>(
+      static_cast<std::underlying_type_t<log_severity>>(
+          std::min(log_severity::delimiter, level)));
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+  return labels[index];
+}
+#undef BINSRV_LOG_SEVERITY_X_SEQUENCE
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+} // namespace binsrv
+
+#endif // BINSRV_LOG_SEVERITY_HPP

--- a/src/binsrv/log_severity_fwd.hpp
+++ b/src/binsrv/log_severity_fwd.hpp
@@ -1,0 +1,12 @@
+#ifndef BINSRV_LOG_SEVERITY_FWD_HPP
+#define BINSRV_LOG_SEVERITY_FWD_HPP
+
+#include <cstdint>
+
+namespace binsrv {
+
+enum class log_severity : std::uint8_t;
+
+} // namespace binsrv
+
+#endif // BINSRV_LOG_SEVERITY_FWD_HPP

--- a/src/binsrv/ostream_logger.hpp
+++ b/src/binsrv/ostream_logger.hpp
@@ -9,8 +9,8 @@ namespace binsrv {
 
 class [[nodiscard]] ostream_logger : public basic_logger {
 public:
-  explicit ostream_logger(std::ostream &stream)
-      : basic_logger{}, stream_{&stream} {}
+  ostream_logger(log_severity min_level, std::ostream &stream)
+      : basic_logger{min_level}, stream_{&stream} {}
 
 private:
   std::ostream *stream_;

--- a/src/easymysql/binlog.cpp
+++ b/src/easymysql/binlog.cpp
@@ -33,6 +33,9 @@ binlog::binlog(connection &conn, std::uint32_t server_id)
                                         .file_name = nullptr,
                                         .start_position = magic_binlog_offset,
                                         .server_id = server_id,
+                                        // TODO: consider adding (or-ing)
+                                        // BINLOG_DUMP_NON_BLOCK and
+                                        // MYSQL_RPL_SKIP_HEARTBEAT to flags
                                         .flags = 0,
                                         .gtid_set_encoded_size = 0,
                                         .fix_gtid_set = nullptr,

--- a/src/easymysql/connection.cpp
+++ b/src/easymysql/connection.cpp
@@ -75,7 +75,7 @@ binlog connection::create_binlog(std::uint32_t server_id) {
 void connection::execute_generic_query_noresult(std::string_view query) {
   assert(!is_empty());
   auto *casted_impl = connection_deimpl::get(impl_);
-  if (mysql_real_query(casted_impl, query.data(), query.size()) != 0) {
+  if (mysql_real_query(casted_impl, std::data(query), std::size(query)) != 0) {
     raise_core_error_from_connection(*this);
   }
 }

--- a/src/easymysql/connection_config.cpp
+++ b/src/easymysql/connection_config.cpp
@@ -55,7 +55,8 @@ connection_config::connection_config(std::string_view file_name)
   }
 
   std::string file_content(file_size, 'x');
-  if (!ifs.read(file_content.data(), static_cast<std::streamoff>(file_size))) {
+  if (!ifs.read(std::data(file_content),
+                static_cast<std::streamoff>(file_size))) {
     util::exception_location().raise<std::invalid_argument>(
         "cannot read configuration file content");
   }

--- a/src/util/exception_helpers.hpp
+++ b/src/util/exception_helpers.hpp
@@ -27,11 +27,10 @@ public:
   }
 };
 
-// deliberately without [[nodiscard]] as this class is supposed to be used
-// as a helper only
+// this class is supposed to be used as a helper only
 // e.g. exception_location().raise<std::invalid_argument>(
 //   "value cannot be zero")
-class exception_location {
+class [[nodiscard]] exception_location {
 public:
   explicit exception_location(
       std::source_location location = std::source_location::current())

--- a/src/util/flag_set.hpp
+++ b/src/util/flag_set.hpp
@@ -1,0 +1,104 @@
+#ifndef UTIL_FLAG_SET_HPP
+#define UTIL_FLAG_SET_HPP
+
+#include "util/flag_set_fwd.hpp"
+
+#include <bit>
+#include <cassert>
+#include <climits>
+#include <string>
+#include <type_traits>
+
+namespace util {
+
+template <typename E>
+requires std::is_enum_v<E>
+class [[nodiscard]] flag_set {
+public:
+  using element_type = E;
+  using this_type = flag_set<element_type>;
+  using underlying_type = std::underlying_type_t<element_type>;
+
+  flag_set() noexcept = default;
+  explicit flag_set(underlying_type bits) noexcept : bits_{bits} {}
+  // deliberately allow implicit conversions
+  // NOLINTNEXTLINE(hicpp-explicit-conversions)
+  flag_set(element_type element) noexcept : bits_{element} {
+    assert(std::has_single_bit(bits_));
+  }
+  [[nodiscard]] bool is_empty() const noexcept {
+    return bits_ == underlying_type{};
+  }
+  [[nodiscard]] bool has_element(element_type element) const noexcept {
+    auto underlying = static_cast<underlying_type>(element);
+    assert(std::has_single_bit(underlying));
+    return (bits_ & underlying) != underlying_type{};
+  }
+  void set_element(element_type element) noexcept {
+    auto underlying = static_cast<underlying_type>(element);
+    assert(std::has_single_bit(underlying));
+    bits_ &= underlying;
+  }
+  void flip_element(element_type element) noexcept {
+    auto underlying = static_cast<underlying_type>(element);
+    assert(std::has_single_bit(underlying));
+    bits_ ^= underlying;
+  }
+
+  [[nodiscard]] underlying_type get_bits() const noexcept { return bits_; }
+
+  this_type &operator&=(this_type other) noexcept {
+    bits_ &= other.bits_;
+    return *this;
+  }
+  this_type &operator|=(this_type other) noexcept {
+    bits_ |= other.bits_;
+    return *this;
+  }
+  this_type &operator^=(this_type other) noexcept {
+    bits_ ^= other.bits_;
+    return *this;
+  }
+
+private:
+  underlying_type bits_;
+};
+
+template <typename E>
+requires std::is_enum_v<E>
+[[nodiscard]] flag_set<E> operator|(flag_set<E> first,
+                                    flag_set<E> second) noexcept {
+  auto res = first;
+  res |= second;
+  return res;
+}
+
+template <typename E>
+requires std::is_enum_v<E>
+[[nodiscard]] flag_set<E> operator&(flag_set<E> first,
+                                    flag_set<E> second) noexcept {
+  auto res = first;
+  res &= second;
+  return res;
+}
+
+template <typename E>
+requires std::is_enum_v<E>
+[[nodiscard]] std::string to_string(flag_set<E> flags) {
+  auto bits = flags.get_bits();
+  auto mask = static_cast<decltype(bits)>(1);
+  std::string res;
+  for (std::size_t idx = 0; idx < sizeof(bits) * CHAR_BIT; ++idx, mask <<= 1U) {
+    if ((bits & mask) != 0) {
+      if (!res.empty()) {
+        res += " | ";
+      }
+      res += to_string_view(static_cast<E>(mask));
+    }
+  }
+  return res;
+}
+
+} // namespace util
+
+#endif // UTIL_FLAG_SET_HPP

--- a/src/util/flag_set_fwd.hpp
+++ b/src/util/flag_set_fwd.hpp
@@ -1,0 +1,14 @@
+#ifndef UTIL_FLAG_SET_FWD_HPP
+#define UTIL_FLAG_SET_FWD_HPP
+
+#include <type_traits>
+
+namespace util {
+
+template <typename E>
+requires std::is_enum_v<E>
+class flag_set;
+
+} // namespace util
+
+#endif // UTIL_FLAG_SET_FWD_HPP


### PR DESCRIPTION
'basic_logger' class (and, therefore, 'ostream_logger' class) now accept severity as an input parameter in the constructor.

'log_severity' "smart" enum extracted into separate file. Added 'event_type' "smart" enum to represent binary log event type code. Added 'event_flag' "smart" enum to represent binary log event bit flags.

Added generic 'flag_set' class template to the 'util' namespace that can be used to represent a bit set based on a "smart" enum.

Added 'event_header' class that can represent generic binary log event header:
* timestamp
* type code
* server id
* event size
* next event position
* flags

Main application is now able to extract binlog event common headers from the event stream and dump their content.