### PR TITLE
Command line arguments are now printed to the log

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -59,11 +59,11 @@ int main(int argc, char *argv[]) {
 
   const auto cmd_args = util::to_command_line_agg_view(argc, argv);
   const auto number_of_cmd_args = std::size(cmd_args);
+  const auto executable_name = util::extract_executable_name(cmd_args);
 
   if (number_of_cmd_args !=
           easymysql::connection_config::expected_number_of_arguments + 1 &&
       number_of_cmd_args != 2) {
-    auto executable_name = util::extract_executable_name(cmd_args);
     std::cerr << "usage: " << executable_name
               << " <host> <port> <user> <password>\n"
               << "       " << executable_name << " <json_config_file>\n";
@@ -78,6 +78,11 @@ int main(int argc, char *argv[]) {
     const auto log_level_label =
         binsrv::to_string_view(logger->get_min_level());
     // logging with "delimiter" level has the highest priority and empty label
+    logger->log(binsrv::log_severity::delimiter,
+                '"' + executable_name + '"' +
+                    " started with the following command line arguments:");
+    logger->log(binsrv::log_severity::delimiter,
+                util::get_readable_command_line_arguments(cmd_args));
     logger->log(binsrv::log_severity::delimiter,
                 "logging level set to \""s + std::string{log_level_label} +
                     '"');

--- a/src/util/command_line_helpers.cpp
+++ b/src/util/command_line_helpers.cpp
@@ -11,11 +11,34 @@ std::string extract_executable_name(util::command_line_arg_view cmd_args) {
     try {
       const std::filesystem::path executable_path{cmd_args[0]};
       auto filename = executable_path.filename();
+      res = filename.string();
     } catch (const std::exception &) {
     }
   }
   if (res.empty()) {
     res = "executable";
+  }
+  return res;
+}
+
+std::string
+get_readable_command_line_arguments(util::command_line_arg_view cmd_args) {
+  std::string res;
+  if (cmd_args.empty()) {
+    return res;
+  }
+  const auto shifted_cmd_args = cmd_args.subspan(1);
+
+  bool first = true;
+  for (const auto *arg : shifted_cmd_args) {
+    if (first) {
+      first = false;
+    } else {
+      res += ' ';
+    }
+    res += '"';
+    res += arg;
+    res += '"';
   }
   return res;
 }

--- a/src/util/command_line_helpers.hpp
+++ b/src/util/command_line_helpers.hpp
@@ -18,6 +18,9 @@ inline command_line_arg_view to_command_line_agg_view(
 [[nodiscard]] std::string
 extract_executable_name(util::command_line_arg_view cmd_args);
 
+[[nodiscard]] std::string
+get_readable_command_line_arguments(util::command_line_arg_view cmd_args);
+
 } // namespace util
 
 #endif // UTIL_COMMAND_LINE_HELPERS_HPP


### PR DESCRIPTION
Fixed bug with improper detection of the executable name ("argv[0]").