### PR TITLE
Implemented helpers for extensible config settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,12 +60,18 @@ set(source_files
 
   src/util/conversion_helpers.hpp
 
+  src/util/ct_string.hpp
+
   src/util/exception_helpers.hpp
 
   src/util/flag_set_fwd.hpp
   src/util/flag_set.hpp
 
   src/util/impl_helpers.hpp
+
+  src/util/nv_tuple.hpp
+  src/util/nv_tuple_from_command_line.hpp
+  src/util/nv_tuple_from_json.hpp
 
   src/easymysql/core_error_helpers_private.hpp
   src/easymysql/core_error_helpers_private.cpp

--- a/connection_config.json
+++ b/connection_config.json
@@ -1,6 +1,6 @@
 {
   "host": "127.0.0.1",
-  "port": 3306,
+  "port": 13000,
   "user": "root",
-  "password": "passw0rd"
+  "password": ""
 }

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -19,6 +19,7 @@
 
 #include "util/command_line_helpers.hpp"
 #include "util/exception_helpers.hpp"
+#include "util/nv_tuple.hpp"
 
 void log_span_dump(binsrv::basic_logger &logger,
                    easymysql::binlog_stream_span portion) {
@@ -61,8 +62,7 @@ int main(int argc, char *argv[]) {
   const auto number_of_cmd_args = std::size(cmd_args);
   const auto executable_name = util::extract_executable_name(cmd_args);
 
-  if (number_of_cmd_args !=
-          easymysql::connection_config::expected_number_of_arguments + 1 &&
+  if (number_of_cmd_args != easymysql::connection_config::size + 1 &&
       number_of_cmd_args != 2) {
     std::cerr << "usage: " << executable_name
               << " <host> <port> <user> <password>\n"
@@ -92,12 +92,12 @@ int main(int argc, char *argv[]) {
       logger->log(binsrv::log_severity::info,
                   "Reading connection configuration from the JSON file.");
       config = std::make_shared<easymysql::connection_config>(cmd_args[1]);
-    } else if (number_of_cmd_args ==
-               easymysql::connection_config::expected_number_of_arguments + 1) {
+    } else if (number_of_cmd_args == easymysql::connection_config::size + 1) {
       logger->log(binsrv::log_severity::info,
                   "Reading connection configuration from the command line "
-                  "parameters.");
-      config = std::make_shared<easymysql::connection_config>(cmd_args);
+                  "arguments.");
+      config =
+          std::make_shared<easymysql::connection_config>(cmd_args.subspan(1U));
     } else {
       assert(false);
     }
@@ -145,7 +145,7 @@ int main(int argc, char *argv[]) {
         util::exception_location().raise<std::invalid_argument>(
             "unexpected event prefix");
       }
-      portion = portion.subspan(1);
+      portion = portion.subspan(1U);
       logger->log(binsrv::log_severity::info,
                   "fetched " + std::to_string(std::size(portion)) +
                       "-byte(s) event from binlog");

--- a/src/binsrv/event_header.cpp
+++ b/src/binsrv/event_header.cpp
@@ -27,12 +27,12 @@ read_fixed_int_from_span(easymysql::binlog_stream_span portion) noexcept {
 }
 
 template <std::integral T>
-bool extract_int_fixed_int_from_stream(easymysql::binlog_stream_span &remainder,
-                                       T &value) noexcept {
+bool extract_fixed_int_from_stream(easymysql::binlog_stream_span &remainder,
+                                   T &value) noexcept {
   if (std::size(remainder) < sizeof(T)) {
     return false;
   }
-  value = read_fixed_int_from_span<T>(remainder.subspan(0, sizeof(T)));
+  value = read_fixed_int_from_span<T>(remainder.subspan(0U, sizeof(T)));
   remainder = remainder.subspan(sizeof(T));
   return true;
 }
@@ -66,12 +66,12 @@ event_header::event_header(easymysql::binlog_stream_span portion) {
    */
   auto remainder = portion;
   auto result =
-      extract_int_fixed_int_from_stream(remainder, timestamp_) &&
-      extract_int_fixed_int_from_stream(remainder, type_code_) &&
-      extract_int_fixed_int_from_stream(remainder, server_id_) &&
-      extract_int_fixed_int_from_stream(remainder, event_size_) &&
-      extract_int_fixed_int_from_stream(remainder, next_event_position_) &&
-      extract_int_fixed_int_from_stream(remainder, flags_);
+      extract_fixed_int_from_stream(remainder, timestamp_) &&
+      extract_fixed_int_from_stream(remainder, type_code_) &&
+      extract_fixed_int_from_stream(remainder, server_id_) &&
+      extract_fixed_int_from_stream(remainder, event_size_) &&
+      extract_fixed_int_from_stream(remainder, next_event_position_) &&
+      extract_fixed_int_from_stream(remainder, flags_);
   if (!result) {
     util::exception_location().raise<std::invalid_argument>(
         "invalid event header");

--- a/src/easymysql/connection.cpp
+++ b/src/easymysql/connection.cpp
@@ -29,11 +29,11 @@ connection::connection(const connection_config &config)
   }
   auto *casted_impl = connection_deimpl::get(impl_);
   if (mysql_real_connect(casted_impl,
-                         /*        host */ config.get_host().c_str(),
-                         /*        user */ config.get_user().c_str(),
-                         /*    password */ config.get_password().c_str(),
+                         /*        host */ config.get<"host">().c_str(),
+                         /*        user */ config.get<"user">().c_str(),
+                         /*    password */ config.get<"password">().c_str(),
                          /*          db */ nullptr,
-                         /*        port */ config.get_port(),
+                         /*        port */ config.get<"port">(),
                          /* unix socket */ nullptr,
                          /*       flags */ 0) == nullptr) {
     raise_core_error_from_connection(*this);

--- a/src/easymysql/connection_config.cpp
+++ b/src/easymysql/connection_config.cpp
@@ -9,33 +9,21 @@
 #include <boost/json/src.hpp>
 
 #include "util/exception_helpers.hpp"
-
-namespace {
-
-constexpr std::string_view key_host{"host"};
-constexpr std::string_view key_port{"port"};
-constexpr std::string_view key_user{"user"};
-constexpr std::string_view key_password{"password"};
-
-} // anonymous namespace
+#include "util/nv_tuple_from_command_line.hpp"
+#include "util/nv_tuple_from_json.hpp"
 
 namespace easymysql {
 
-connection_config::connection_config(util::command_line_arg_view arguments)
-    : host_{arguments[1]}, port_{0}, user_{arguments[3]},
-      password_{arguments[4]} {
-  const auto *port_bg = arguments[2];
-  const auto *port_en = std::next(
-      port_bg, static_cast<std::ptrdiff_t>(std::strlen(arguments[2])));
-  auto [ptr, ec] = std::from_chars(port_bg, port_en, port_);
-  if (ec != std::errc() || ptr != port_en) {
+connection_config::connection_config(util::command_line_arg_view arguments) {
+  try {
+    util::nv_tuple_from_command_line(arguments, *this);
+  } catch (const std::exception &) {
     util::exception_location().raise<std::invalid_argument>(
-        "invalid port value");
+        "cannot extract configuration values from the command line");
   }
 }
 
-connection_config::connection_config(std::string_view file_name)
-    : host_{}, port_{0}, user_{}, password_{} {
+connection_config::connection_config(std::string_view file_name) {
   static constexpr std::size_t max_file_size = 1048576;
 
   const std::filesystem::path file_path{file_name};
@@ -63,14 +51,7 @@ connection_config::connection_config(std::string_view file_name)
 
   try {
     auto json_value = boost::json::parse(file_content);
-    const auto &json_object = json_value.as_object();
-
-    host_ = boost::json::value_to<decltype(host_)>(json_object.at(key_host));
-    port_ = boost::json::value_to<decltype(port_)>(json_object.at(key_port));
-    user_ = boost::json::value_to<decltype(user_)>(json_object.at(key_user));
-    password_ = boost::json::value_to<decltype(password_)>(
-        json_object.at(key_password));
-
+    util::nv_tuple_from_json(json_value, *this);
   } catch (const std::exception &) {
     util::exception_location().raise<std::invalid_argument>(
         "cannot parse JSON configuration file");
@@ -78,7 +59,8 @@ connection_config::connection_config(std::string_view file_name)
 }
 
 std::string connection_config::get_connection_string() const {
-  return get_user() + '@' + get_host() + ':' + std::to_string(get_port()) +
+  return get<"user">() + '@' + get<"host">() + ':' +
+         std::to_string(get<"port">()) +
          (has_password() ? " (password ***hidden***)" : " (no password)");
 }
 

--- a/src/easymysql/connection_config.hpp
+++ b/src/easymysql/connection_config.hpp
@@ -8,40 +8,29 @@
 #include <string_view>
 
 #include "util/command_line_helpers_fwd.hpp"
+#include "util/nv_tuple.hpp"
 
 namespace easymysql {
 
-class [[nodiscard]] connection_config {
+class [[nodiscard]] connection_config
+    : public util::nv_tuple<
+          // clang-format off
+          util::nv<"host"    , std::string>,
+          util::nv<"port"    , std::uint16_t>,
+          util::nv<"user"    , std::string>,
+          util::nv<"password", std::string>
+          // clang-format on
+          > {
 public:
-  static constexpr std::size_t expected_number_of_arguments = 4;
-
-  // NOLINTBEGIN(bugprone-easily-swappable-parameters)
-  connection_config(std::string_view host, std::uint16_t port,
-                    std::string_view user, std::string_view password)
-      : host_{host}, port_{port}, user_{user}, password_{password} {}
-  // NOLINTEND(bugprone-easily-swappable-parameters)
-
   explicit connection_config(std::string_view file_name);
 
   explicit connection_config(util::command_line_arg_view arguments);
 
-  [[nodiscard]] const std::string &get_host() const noexcept { return host_; }
-  [[nodiscard]] std::uint16_t get_port() const noexcept { return port_; }
-  [[nodiscard]] const std::string &get_user() const noexcept { return user_; }
-  [[nodiscard]] const std::string &get_password() const noexcept {
-    return password_;
-  }
   [[nodiscard]] bool has_password() const noexcept {
-    return !password_.empty();
+    return !get<"password">().empty();
   }
 
   [[nodiscard]] std::string get_connection_string() const;
-
-private:
-  std::string host_;
-  std::uint16_t port_;
-  std::string user_;
-  std::string password_;
 };
 
 } // namespace easymysql

--- a/src/util/command_line_helpers.cpp
+++ b/src/util/command_line_helpers.cpp
@@ -27,7 +27,7 @@ get_readable_command_line_arguments(util::command_line_arg_view cmd_args) {
   if (cmd_args.empty()) {
     return res;
   }
-  const auto shifted_cmd_args = cmd_args.subspan(1);
+  const auto shifted_cmd_args = cmd_args.subspan(1U);
 
   bool first = true;
   for (const auto *arg : shifted_cmd_args) {

--- a/src/util/ct_string.hpp
+++ b/src/util/ct_string.hpp
@@ -1,0 +1,47 @@
+#ifndef UTIL_CT_STRING_HPP
+#define UTIL_CT_STRING_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <string_view>
+
+namespace util {
+
+// in order for ct_string to be a non-type template argument, all its non-static
+// members must be public
+// for convenience, the instances of this class should be implicitly created
+// from the string literals (const char(&)[])
+template <std::size_t N> struct ct_string {
+  // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+  // NOLINTNEXTLINE(hicpp-explicit-conversions)
+  constexpr ct_string(const char (&str)[N]) noexcept {
+    std::copy_n(std::cbegin(str), N, std::begin(data));
+  }
+  // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+
+  [[nodiscard]] constexpr const char *c_str() const noexcept {
+    return std::cbegin(data);
+  }
+  [[nodiscard]] constexpr std::size_t size() const noexcept { return N - 1; }
+  [[nodiscard]] constexpr std::string_view sv() const noexcept {
+    return {std::cbegin(data), N - 1};
+  }
+  // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+  char data[N] = {}; // NOLINT(misc-non-private-member-variables-in-classes)
+  // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+};
+
+template <std::size_t N1, std::size_t N2>
+constexpr inline auto operator==(const ct_string<N1> &cts1,
+                                 const ct_string<N2> &cts2) noexcept {
+  return cts1.sv() == cts2.sv();
+}
+template <std::size_t N1, std::size_t N2>
+constexpr inline auto operator<=>(const ct_string<N1> &cts1,
+                                  const ct_string<N2> &cts2) noexcept {
+  return cts1.sv() <=> cts2.sv();
+}
+
+} // namespace util
+
+#endif // UTIL_CT_STRING_HPP

--- a/src/util/nv_tuple.hpp
+++ b/src/util/nv_tuple.hpp
@@ -1,0 +1,76 @@
+#ifndef UTIL_NV_TUPLE_HPP
+#define UTIL_NV_TUPLE_HPP
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "util/ct_string.hpp"
+
+namespace util {
+
+// most probably due to a bug in the bugprone-exception-escape
+// clanng-tidy rule logic, the exception that may potentially come from the
+// special functions of both nv and nv_tuple class templates is not properly
+// handled
+
+// NOLINTNEXTLINE(bugprone-exception-escape)
+template <ct_string CTS, typename T> struct nv {
+  using type = T;
+  static constexpr decltype(CTS) name = CTS;
+
+  type value;
+};
+
+// NOLINTNEXTLINE(bugprone-exception-escape)
+template <typename... NVPack> struct nv_tuple : NVPack... {
+  // TODO: add constraint to make sure that all NVPack elements are of type nv
+  // TODO: add constraint to make sure that we have only uniqie names in the
+  //       NVPack
+  static constexpr std::size_t size = sizeof...(NVPack);
+
+  template <std::size_t Index>
+  using index_to_base = std::tuple_element_t<Index, std::tuple<NVPack...>>;
+
+  template <std::size_t Index> [[nodiscard]] const auto &get() const noexcept {
+    static_assert(Index < size, "nv_tuple index is out of range");
+    return index_to_base<Index>::value;
+  }
+  template <std::size_t Index> [[nodiscard]] auto &get() noexcept {
+    static_assert(Index < size, "nv_tuple index is out of range");
+    return index_to_base<Index>::value;
+  }
+
+  template <ct_string CTS>
+  static constexpr std::size_t name_to_index_v =
+      // we use immediately invoked lambda here to calculate the index
+      // of the element in the NVPack whose name is equal to CTS
+      []<std::size_t... IndexPack>(std::index_sequence<IndexPack...>) {
+    // here we use a fold expression to calculatethe sum of all the indexes
+    // that correspond to an element with name equal to CTS
+    // pseudo code:
+    // std::size_t res = 0;
+    // for constexpr (std::size_t i = 0; i < sizeof...(NVPack); ++i)
+    //   if constexpr (index_to_base<i>::name == CTS) res += (i + 1);
+    // return res == 0 ? size : res - 1;
+    auto res = ((index_to_base<IndexPack>::name == CTS ? IndexPack + 1U : 0U) +
+                ... + 0U);
+    return res == 0 ? size : res - 1;
+  }
+  (std::index_sequence_for<NVPack...>{});
+
+  template <ct_string CTS> [[nodiscard]] const auto &get() const noexcept {
+    static constexpr std::size_t found_index = name_to_index_v<CTS>;
+    static_assert(found_index < size, "unknown nv_tuple element name");
+    return get<found_index>();
+  }
+  template <ct_string CTS> [[nodiscard]] auto &get() noexcept {
+    static constexpr std::size_t found_index = name_to_index_v<CTS>;
+    static_assert(found_index < size, "unknown nv_tuple element name");
+    return get<found_index>();
+  }
+};
+
+} // namespace util
+
+#endif // UTIL_NV_TUPLE_HPP

--- a/src/util/nv_tuple_from_command_line.hpp
+++ b/src/util/nv_tuple_from_command_line.hpp
@@ -1,0 +1,22 @@
+#ifndef UTIL_NV_TUPLE_FROM_COMMAND_LINE_HPP
+#define UTIL_NV_TUPLE_FROM_COMMAND_LINE_HPP
+
+#include <boost/lexical_cast.hpp>
+
+#include "util/command_line_helpers_fwd.hpp"
+#include "util/nv_tuple.hpp"
+
+namespace util {
+
+template <typename... NVPack>
+void nv_tuple_from_command_line(util::command_line_arg_view arguments,
+                                nv_tuple<NVPack...> &obj) {
+  std::size_t index = 0;
+  ((obj.NVPack::value =
+        boost::lexical_cast<typename NVPack::type>(arguments[index++])),
+   ...);
+}
+
+} // namespace util
+
+#endif // UTIL_NV_TUPLE_FROM_COMMAND_LINE_HPP

--- a/src/util/nv_tuple_from_json.hpp
+++ b/src/util/nv_tuple_from_json.hpp
@@ -1,0 +1,22 @@
+#ifndef UTIL_NV_TUPLE_FROM_JSON_HPP
+#define UTIL_NV_TUPLE_FROM_JSON_HPP
+
+#include <boost/json/value.hpp>
+#include <boost/json/value_to.hpp>
+
+#include "util/nv_tuple.hpp"
+
+namespace util {
+
+template <typename... NVPack>
+void nv_tuple_from_json(const boost::json::value &json_value,
+                        nv_tuple<NVPack...> &obj) {
+  const auto &json_object = json_value.as_object();
+  ((obj.NVPack::value = boost::json::value_to<typename NVPack::type>(
+        json_object.at(NVPack::name.sv()))),
+   ...);
+}
+
+} // namespace util
+
+#endif // UTIL_NV_TUPLE_FROM_JSON_HPP


### PR DESCRIPTION
Introduced 'ct_ctring' struct template which is supposed to be used as a compile time string in non-type template arguments. Due to CTAD it is now possible to declare
template<ct_string CTS> struct named_struct;
and use string literals directly as template arguments using foo_named_struct = named_struct<"foo">;

Introduced 'nv' struct template which can be used as a labeled value type (a type with associated compile-time name):
e.g.
using port_value = nv<"port", std::uint16_t>;

Introduced 'nv_tuple ' struct template which takes a variadic number of 'nv' types and serves a a collection of labeled values: e.g.
using endpoint_tuple = nv_tuple<
  nv<"host", std::string>,
  nv<"port", std::uint16_t>>;
endpoint_tuple endpoint;
The interface allows to access elements by index
const auto& host = endpoint.get<0>();
or by label
const auto& port = endpoint.get<"port">();

Introduced 'nv_tuple_from_json()' helper function which extracts 'nv_tuple' elements from the provided 'boost::json::value' object.

Introduded 'nv_tuple_from_command_line()' helper function that extracts 'nv_tuple' elements from the command line arguments (uses 'boost::lexical_cast<>()' for converting from strings).

'easymysql::connection_config' class reworked using 'nv_tuple'.

Fixed 'extract_fixed_int_from_stream()' function name.

Default connection parameters in the 'connection_config.json' changed to correspond to default ones provided by './mtr --start ...'.