### PR TITLE
Added reader_context class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,14 @@ set(source_files
   src/binsrv/event/generic_post_header_fwd.hpp
   src/binsrv/event/generic_post_header.hpp
 
+  src/binsrv/event/protocol_traits_fwd.hpp
+  src/binsrv/event/protocol_traits.hpp
+  src/binsrv/event/protocol_traits.cpp
+
+  src/binsrv/event/reader_context_fwd.hpp
+  src/binsrv/event/reader_context.hpp
+  src/binsrv/event/reader_context.cpp
+
   src/binsrv/event/rotate_body_impl_fwd.hpp
   src/binsrv/event/rotate_body_impl.hpp
   src/binsrv/event/rotate_body_impl.cpp

--- a/src/binsrv/event/common_header.hpp
+++ b/src/binsrv/event/common_header.hpp
@@ -10,6 +10,7 @@
 
 #include "binsrv/event/code_type_fwd.hpp"
 #include "binsrv/event/flag_type_fwd.hpp"
+#include "binsrv/event/protocol_traits_fwd.hpp"
 
 #include "util/byte_span_fwd.hpp"
 
@@ -17,7 +18,7 @@ namespace binsrv::event {
 
 class [[nodiscard]] common_header {
 public:
-  static constexpr std::size_t size_in_bytes{19U};
+  static constexpr std::size_t size_in_bytes{default_common_header_length};
 
   explicit common_header(util::const_byte_span portion);
 

--- a/src/binsrv/event/format_description_post_header_impl.cpp
+++ b/src/binsrv/event/format_description_post_header_impl.cpp
@@ -1,7 +1,5 @@
 #include "binsrv/event/format_description_post_header_impl.hpp"
 
-#include <cstddef>
-#include <iterator>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -16,7 +14,6 @@
 
 #include "util/byte_span.hpp"
 #include "util/byte_span_extractors.hpp"
-#include "util/conversion_helpers.hpp"
 #include "util/exception_location_helpers.hpp"
 
 namespace binsrv::event {
@@ -49,11 +46,6 @@ generic_post_header_impl<code_type::format_description>::
                 "mismatch in "
                 "generic_post_header_impl<code_type::format_description>::"
                 "server_version_length");
-  static_assert(number_of_events ==
-                    util::enum_to_index(code_type::delimiter) - 1U,
-                "mismatch in "
-                "generic_post_header_impl<code_type::format_description>::"
-                "number_of_events");
 
   // TODO: initialize size_in_bytes directly based on the sum of fields
   // widths instead of this static_assert
@@ -101,19 +93,6 @@ generic_post_header_impl<code_type::format_description>::get_server_version()
     code_type::format_description>::get_readable_create_timestamp() const {
   return boost::posix_time::to_simple_string(
       boost::posix_time::from_time_t(get_create_timestamp()));
-}
-
-[[nodiscard]] std::size_t
-generic_post_header_impl<code_type::format_description>::get_post_header_length(
-    code_type code) const noexcept {
-  // here the very first "unknown" code is not included in the array by the
-  // spec
-  const auto index{util::enum_to_index(code)};
-  if (index == 0U || index >= util::enum_to_index(code_type::delimiter)) {
-    return 0U;
-  }
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-  return static_cast<std::size_t>(post_header_lengths_[index - 1U]);
 }
 
 } // namespace binsrv::event

--- a/src/binsrv/event/format_description_post_header_impl.hpp
+++ b/src/binsrv/event/format_description_post_header_impl.hpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <string_view>
 
+#include "binsrv/event/protocol_traits.hpp"
+
 #include "util/byte_span_fwd.hpp"
 
 namespace binsrv::event {
@@ -18,15 +20,10 @@ template <>
 class [[nodiscard]] generic_post_header_impl<code_type::format_description> {
 public:
   static constexpr std::size_t server_version_length{50U};
-  static constexpr std::size_t number_of_events{41U};
   static constexpr std::size_t size_in_bytes{98U};
 
-private:
   using server_version_storage = std::array<std::byte, server_version_length>;
-  using post_header_lengths_storage =
-      std::array<std::uint8_t, number_of_events>;
 
-public:
   explicit generic_post_header_impl(util::const_byte_span portion);
 
   [[nodiscard]] std::uint16_t get_binlog_version_raw() const noexcept {
@@ -55,19 +52,21 @@ public:
     return static_cast<std::size_t>(get_common_header_length_raw());
   }
 
-  [[nodiscard]] const post_header_lengths_storage &
+  [[nodiscard]] const post_header_length_container &
   get_post_header_lengths_raw() const noexcept {
     return post_header_lengths_;
   }
   [[nodiscard]] std::size_t
-  get_post_header_length(code_type code) const noexcept;
+  get_post_header_length(code_type code) const noexcept {
+    return get_post_header_length_for_code(post_header_lengths_, code);
+  }
 
 private:
   // the members are deliberately reordered for better packing
   std::uint32_t create_timestamp_{};                  // 2
   server_version_storage server_version_{};           // 1
   std::uint16_t binlog_version_{};                    // 0
-  post_header_lengths_storage post_header_lengths_{}; // 4
+  post_header_length_container post_header_lengths_{}; // 4
   std::uint8_t common_header_length_{};               // 3
 };
 

--- a/src/binsrv/event/protocol_traits.cpp
+++ b/src/binsrv/event/protocol_traits.cpp
@@ -1,0 +1,28 @@
+#include "binsrv/event/protocol_traits.hpp"
+
+#include <cstddef>
+
+#include "binsrv/event/code_type.hpp"
+
+#include "util/conversion_helpers.hpp"
+
+namespace binsrv::event {
+
+[[nodiscard]] std::size_t
+get_post_header_length_for_code(const post_header_length_container &storage,
+                                code_type code) noexcept {
+  static_assert(default_number_of_events ==
+                    util::enum_to_index(code_type::delimiter),
+                "mismatch between number_of_events and code_type enum");
+
+  // here the very first "unknown" code is not included in the array by the
+  // spec
+  const auto index{util::enum_to_index(code)};
+  if (index == 0U || index >= default_number_of_events) {
+    return 0U;
+  }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+  return static_cast<std::size_t>(storage[index - 1U]);
+}
+
+} // namespace binsrv::event

--- a/src/binsrv/event/protocol_traits.hpp
+++ b/src/binsrv/event/protocol_traits.hpp
@@ -1,0 +1,24 @@
+#ifndef BINSRV_EVENT_PROTOCOL_TRAITS_HPP
+#define BINSRV_EVENT_PROTOCOL_TRAITS_HPP
+
+#include "binsrv/event/protocol_traits_fwd.hpp" // IWYU pragma: export
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include "binsrv/event/code_type_fwd.hpp"
+
+namespace binsrv::event {
+
+// we do not store length for the first element which is the "unknown" event
+using post_header_length_container =
+    std::array<std::uint8_t, default_number_of_events - 1U>;
+
+[[nodiscard]] std::size_t
+get_post_header_length_for_code(const post_header_length_container &storage,
+                                code_type code) noexcept;
+
+} // namespace binsrv::event
+
+#endif // BINSRV_EVENT_PROTOCOL_TRAITS_HPP

--- a/src/binsrv/event/protocol_traits_fwd.hpp
+++ b/src/binsrv/event/protocol_traits_fwd.hpp
@@ -1,0 +1,15 @@
+#ifndef BINSRV_EVENT_PROTOCOL_TRAITS_FWD_HPP
+#define BINSRV_EVENT_PROTOCOL_TRAITS_FWD_HPP
+
+#include <cstddef>
+#include <cstdint>
+
+namespace binsrv::event {
+
+inline constexpr std::uint16_t default_binlog_version{4U};
+inline constexpr std::size_t default_number_of_events{42U};
+inline constexpr std::size_t default_common_header_length{19U};
+
+} // namespace binsrv::event
+
+#endif // BINSRV_EVENT_PROTOCOL_TRAITS_FWD_HPP

--- a/src/binsrv/event/reader_context.cpp
+++ b/src/binsrv/event/reader_context.cpp
@@ -1,0 +1,38 @@
+#include "binsrv/event/reader_context.hpp"
+
+#include "binsrv/event/checksum_algorithm_type.hpp"
+#include "binsrv/event/code_type.hpp"
+#include "binsrv/event/event.hpp"
+
+namespace binsrv::event {
+
+reader_context::reader_context()
+    : checksum_algorithm_{checksum_algorithm_type::off} {}
+
+void reader_context::process_event(const event &current_event) {
+  // TODO: add some kind of state machine where the expected sequence of events
+  //       is the following -
+  //       (ROTATE(artificial) FORMAT_DESCRIPTION <ANY>* ROTATE)*
+  if (current_event.get_common_header().get_type_code() ==
+      code_type::format_description) {
+    const auto &post_header{
+        current_event.get_post_header<code_type::format_description>()};
+    const auto &body{current_event.get_body<code_type::format_description>()};
+
+    // TODO: check if binlog_version == default_binlog_version
+    // TODO: check if common_header_length == default_common_header_length
+    // TODO: check if post_header_lengths for known events has expected
+    //       generic_post_header_impl<code_type::xxx>::size_in_bytes
+    //       (at least for 'format_description' and 'rotate')
+
+    fde_processed_ = true;
+    post_header_lengths_ = post_header.get_post_header_lengths_raw();
+    checksum_algorithm_ = body.get_checksum_algorithm();
+  }
+  // TODO: add position counter and check if common_header.event_size /
+  //       common_header. next_event_position match this counter
+  // TODO: check if CRC32 checksum from the footer (if present) matches the
+  //       calculated one
+}
+
+} // namespace binsrv::event

--- a/src/binsrv/event/reader_context.hpp
+++ b/src/binsrv/event/reader_context.hpp
@@ -1,0 +1,41 @@
+#ifndef BINSRV_EVENT_READER_CONTEXT_HPP
+#define BINSRV_EVENT_READER_CONTEXT_HPP
+
+#include "binsrv/event/reader_context_fwd.hpp" // IWYU pragma: export
+
+#include "binsrv/event/checksum_algorithm_type_fwd.hpp"
+#include "binsrv/event/event_fwd.hpp"
+#include "binsrv/event/protocol_traits.hpp"
+
+namespace binsrv::event {
+
+class [[nodiscard]] reader_context {
+  friend class event;
+
+public:
+  reader_context();
+
+  [[nodiscard]] bool has_fde_processed() const noexcept {
+    return fde_processed_;
+  }
+  [[nodiscard]] checksum_algorithm_type
+  get_current_checksum_algorithm() const noexcept {
+    return checksum_algorithm_;
+  }
+  [[nodiscard]] std::size_t
+  get_current_post_header_length(code_type code) const noexcept {
+    return get_post_header_length_for_code(post_header_lengths_, code);
+  }
+
+private:
+  bool fde_processed_{false};
+  // NOLINTNEXTLINE(cppcoreguidelines-use-default-member-init,modernize-use-default-member-init)
+  checksum_algorithm_type checksum_algorithm_;
+  post_header_length_container post_header_lengths_{};
+
+  void process_event(const event &current_event);
+};
+
+} // namespace binsrv::event
+
+#endif // BINSRV_EVENT_READER_CONTEXT_HPP

--- a/src/binsrv/event/reader_context_fwd.hpp
+++ b/src/binsrv/event/reader_context_fwd.hpp
@@ -1,0 +1,10 @@
+#ifndef BINSRV_EVENT_READER_CONTEXT_FWD_HPP
+#define BINSRV_EVENT_READER_CONTEXT_FWD_HPP
+
+namespace binsrv::event {
+
+class reader_context;
+
+} // namespace binsrv::event
+
+#endif // BINSRV_EVENT_READER_CONTEXT_FWD_HPP

--- a/src/binsrv/logger_config.hpp
+++ b/src/binsrv/logger_config.hpp
@@ -11,7 +11,6 @@
 
 namespace binsrv {
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 struct [[nodiscard]] logger_config
     : util::nv_tuple<
           // clang-format off

--- a/src/easymysql/connection_config.hpp
+++ b/src/easymysql/connection_config.hpp
@@ -10,7 +10,6 @@
 
 namespace easymysql {
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 struct [[nodiscard]] connection_config
     : util::nv_tuple<
           // clang-format off

--- a/src/util/nv_tuple.hpp
+++ b/src/util/nv_tuple.hpp
@@ -16,12 +16,6 @@
 
 namespace util {
 
-// most probably due to a bug in the bugprone-exception-escape
-// clanng-tidy rule logic, the exception that may potentially come from the
-// special functions of both nv and nv_tuple class templates is not properly
-// handled
-
-// NOLINTNEXTLINE(bugprone-exception-escape)
 template <ct_string CTS, typename T> struct nv {
   using type = T;
   static constexpr decltype(CTS) name{CTS};
@@ -29,7 +23,6 @@ template <ct_string CTS, typename T> struct nv {
   type value;
 };
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 template <named_value... NVPack> struct nv_tuple : NVPack... {
   // TODO: add constraint to make sure that we have only uniqie names in the
   //       NVPack


### PR DESCRIPTION
Introduced "prorocol_traits_fwd.hpp" / "prorocol_traits.hpp" headers with some expected values for Binary Log Protocol V4 constants.

Introduced 'binsrv::event::reader_context' class that is expected to be used for storing information about the sequence of encountered events as well as data that may affect parsing / analyzing subsequent events in the stream.

'binsrv::event::event' constructor now accepts an reference to an instance of the 'reader_context' class where the information about the most recently encountered format description event is kept.

After some bugs were fixed in 'clang-tidy-17', 'bugprone-exception-escape' NOLINT suppressions are no longer needed and were removed.