### PR TITLE
Added binlog event positions checks

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -20,6 +20,7 @@
 
 #include "binsrv/event/code_type.hpp"
 #include "binsrv/event/event.hpp"
+#include "binsrv/event/protocol_traits_fwd.hpp"
 #include "binsrv/event/reader_context.hpp"
 
 #include "easymysql/binlog.hpp"
@@ -205,7 +206,9 @@ int main(int argc, char *argv[]) {
     logger->log(binsrv::log_severity::info, msg);
 
     static constexpr std::uint32_t default_server_id{0U};
-    auto binlog = connection.create_binlog(default_server_id);
+    auto binlog =
+        connection.create_binlog(default_server_id, std::string_view{},
+                                 binsrv::event::magic_binlog_offset);
     logger->log(binsrv::log_severity::info, "opened binary log connection");
 
     // TODO: make sure we write 'Binlog File Header' [ 0xFE 'bin’]` to the

--- a/src/binsrv/event/common_header.cpp
+++ b/src/binsrv/event/common_header.cpp
@@ -77,8 +77,6 @@ common_header::common_header(util::const_byte_span portion) {
         "invalid event code in event header");
   }
   // TODO: check if flags are valid (all the bits have corresponding enum)
-  // TODO: check that events with 'artificial' flag set have timestamp == 0
-  //       and next_event_position == 0
 }
 
 [[nodiscard]] std::string common_header::get_readable_timestamp() const {

--- a/src/binsrv/event/protocol_traits.cpp
+++ b/src/binsrv/event/protocol_traits.cpp
@@ -1,10 +1,15 @@
 #include "binsrv/event/protocol_traits.hpp"
 
+#include <algorithm>
 #include <cstddef>
+#include <iterator>
+#include <stdexcept>
+#include <string>
 
 #include "binsrv/event/code_type.hpp"
 
 #include "util/conversion_helpers.hpp"
+#include "util/exception_location_helpers.hpp"
 
 namespace binsrv::event {
 
@@ -19,10 +24,35 @@ get_post_header_length_for_code(const post_header_length_container &storage,
   // spec
   const auto index{util::enum_to_index(code)};
   if (index == 0U || index >= default_number_of_events) {
-    return 0U;
+    return unspecified_post_header_length;
   }
   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-  return static_cast<std::size_t>(storage[index - 1U]);
+  const auto encoded_length{storage[index - 1U]};
+  return encoded_length == static_cast<encoded_post_header_length_type>(
+                               unspecified_post_header_length)
+             ? unspecified_post_header_length
+             : static_cast<std::size_t>(encoded_length);
+}
+
+void validate_post_header_lengths(
+    const post_header_length_container &runtime,
+    const post_header_length_container &hardcoded) {
+  const auto length_mismatch_result{std::ranges::mismatch(
+      runtime, hardcoded,
+      [](encoded_post_header_length_type real,
+         encoded_post_header_length_type expected) {
+        return expected == static_cast<encoded_post_header_length_type>(
+                               unspecified_post_header_length) ||
+               real == expected;
+      })};
+  if (length_mismatch_result.in2 != std::end(hardcoded)) {
+    const auto offset{static_cast<std::size_t>(
+        std::distance(std::begin(hardcoded), length_mismatch_result.in2))};
+    const std::string label{
+        to_string_view(util::index_to_enum<code_type>(offset + 1U))};
+    util::exception_location().raise<std::logic_error>(
+        "mismatch in expected post header length for '" + label + "' event");
+  }
 }
 
 } // namespace binsrv::event

--- a/src/binsrv/event/protocol_traits.hpp
+++ b/src/binsrv/event/protocol_traits.hpp
@@ -11,13 +11,19 @@
 
 namespace binsrv::event {
 
+using encoded_post_header_length_type = std::uint8_t;
+
 // we do not store length for the first element which is the "unknown" event
 using post_header_length_container =
-    std::array<std::uint8_t, default_number_of_events - 1U>;
+    std::array<encoded_post_header_length_type, default_number_of_events - 1U>;
 
 [[nodiscard]] std::size_t
 get_post_header_length_for_code(const post_header_length_container &storage,
                                 code_type code) noexcept;
+
+void validate_post_header_lengths(
+    const post_header_length_container &runtime,
+    const post_header_length_container &hardcoded);
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/protocol_traits_fwd.hpp
+++ b/src/binsrv/event/protocol_traits_fwd.hpp
@@ -3,12 +3,18 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 namespace binsrv::event {
 
 inline constexpr std::uint16_t default_binlog_version{4U};
 inline constexpr std::size_t default_number_of_events{42U};
 inline constexpr std::size_t default_common_header_length{19U};
+
+inline constexpr std::size_t unspecified_post_header_length{
+    std::numeric_limits<std::size_t>::max()};
+
+inline constexpr std::uint64_t magic_binlog_offset{4ULL};
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/reader_context.cpp
+++ b/src/binsrv/event/reader_context.cpp
@@ -1,22 +1,16 @@
 #include "binsrv/event/reader_context.hpp"
 
-#include <algorithm>
-#include <array>
 #include <cassert>
 #include <cstddef>
-#include <iterator>
+#include <cstdint>
 #include <stdexcept>
-#include <string>
-#include <tuple>
-#include <type_traits>
-#include <utility>
 
 #include "binsrv/event/checksum_algorithm_type.hpp"
 #include "binsrv/event/code_type.hpp"
 #include "binsrv/event/event.hpp"
+#include "binsrv/event/flag_type.hpp"
 #include "binsrv/event/protocol_traits.hpp"
 
-#include "util/conversion_helpers.hpp"
 #include "util/exception_location_helpers.hpp"
 
 namespace binsrv::event {
@@ -25,11 +19,54 @@ reader_context::reader_context()
     : checksum_algorithm_{checksum_algorithm_type::off} {}
 
 void reader_context::process_event(const event &current_event) {
+  const auto &common_header{current_event.get_common_header()};
+  const auto code = common_header.get_type_code();
+  if (code == code_type::rotate &&
+      common_header.get_flags().has_element(flag_type::artificial)) {
+    // we expect an artificial rotate event to be the very first event in the
+    // newly-created binlog file
+    if (position_ != 0U) {
+      util::exception_location().raise<std::logic_error>(
+          "artificial rotate event is not the very first event in a binlog "
+          "file");
+    }
+
+    // check if next event position and timestamp are set  0
+    if (common_header.get_timestamp_raw() != 0U) {
+      util::exception_location().raise<std::logic_error>(
+          "non-zero timestamp found in an artificial rotate event");
+    }
+    if (common_header.get_next_event_position_raw() != 0U) {
+      util::exception_location().raise<std::logic_error>(
+          "non-zero next event position found in an artificial rotate event");
+    }
+    position_ = static_cast<std::uint32_t>(magic_binlog_offset);
+
+  } else {
+    // every other event (including non-artificial rotate event) are
+    // processed the usual way
+
+    // check if common_header.next_event_position matches current position
+    // plus common_header.event_size
+    if (position_ + common_header.get_event_size_raw() !=
+        common_header.get_next_event_position_raw()) {
+      util::exception_location().raise<std::logic_error>(
+          "unexpected next event position on the event common header");
+    }
+    if (code == code_type::rotate) {
+      // normal (non-artificial) event is expected to be the last event in
+      // binlog - so we reset the current position here
+      position_ = 0U;
+    } else {
+      // for every other event we simply advance current position
+      position_ = common_header.get_next_event_position_raw();
+    }
+  }
+
   // TODO: add some kind of state machine where the expected sequence of events
   //       is the following -
   //       (ROTATE(artificial) FORMAT_DESCRIPTION <ANY>* ROTATE)*
-  if (current_event.get_common_header().get_type_code() ==
-      code_type::format_description) {
+  if (code == code_type::format_description) {
     const auto &post_header{
         current_event.get_post_header<code_type::format_description>()};
     const auto &body{current_event.get_body<code_type::format_description>()};
@@ -49,55 +86,13 @@ void reader_context::process_event(const event &current_event) {
 
     // check if the values from the post_header_lengths array are the same as
     // generic_post_header_impl<code_type::xxx>::size_in_bytes for known events
-
-    // here we use a trick with immediately invoked lambda to initialize a
-    // constexpr array which would have expected post header lengths for all
-    // event codes based on generic_post_header<xxx>::size_in_bytes
-
-    // we ignore the very first element in the code_type enum
-    // (code_type::unknown) since the post header length for this value is
-    // simply not included into FDE post header
-
-    // therefore, the size of the array is default_number_of_events - 1
-    using length_container =
-        std::array<std::size_t, default_number_of_events - 1U>;
-    static constexpr length_container expected_post_header_lengths{
-        []<std::size_t... IndexPack>(
-            std::index_sequence<IndexPack...>) -> length_container {
-          return {generic_post_header<util::index_to_enum<code_type>(
-              IndexPack + 1U)>::size_in_bytes...};
-        }(std::make_index_sequence<default_number_of_events - 1U>{})};
-
-    static_assert(
-        std::tuple_size_v<std::remove_cvref_t<
-                decltype(post_header.get_post_header_lengths_raw())>> ==
-            std::tuple_size_v<decltype(expected_post_header_lengths)>,
-        "mismatch in size between expected_header_lengths and "
-        "post_header.get_post_header_lengths_raw()");
-    const auto length_mismatch_result{std::ranges::mismatch(
-        post_header.get_post_header_lengths_raw(), expected_post_header_lengths,
-        [](post_header_length_container::value_type real,
-           std::size_t expected) {
-          return expected == unknown_post_header::size_in_bytes ||
-                 static_cast<std::size_t>(real) == expected;
-        })};
-    if (length_mismatch_result.in2 != std::end(expected_post_header_lengths)) {
-      const auto offset{static_cast<std::size_t>(
-          std::distance(std::begin(expected_post_header_lengths),
-                        length_mismatch_result.in2))};
-      const std::string label{
-          to_string_view(util::index_to_enum<code_type>(offset + 1U))};
-      util::exception_location().raise<std::logic_error>(
-          "mismatch in expected post header length in FDE for '" + label +
-          "' event");
-    }
+    validate_post_header_lengths(post_header.get_post_header_lengths_raw(),
+                                 event::expected_post_header_lengths);
 
     fde_processed_ = true;
     post_header_lengths_ = post_header.get_post_header_lengths_raw();
     checksum_algorithm_ = body.get_checksum_algorithm();
   }
-  // TODO: add position counter and check if common_header.event_size /
-  //       common_header. next_event_position match this counter
   // TODO: check if CRC32 checksum from the footer (if present) matches the
   //       calculated one
 }

--- a/src/binsrv/event/reader_context.hpp
+++ b/src/binsrv/event/reader_context.hpp
@@ -22,12 +22,16 @@ public:
   get_current_checksum_algorithm() const noexcept;
   [[nodiscard]] std::size_t
   get_current_post_header_length(code_type code) const noexcept;
+  [[nodiscard]] std::uint32_t get_current_position() const noexcept {
+    return position_;
+  }
 
 private:
   bool fde_processed_{false};
   // NOLINTNEXTLINE(cppcoreguidelines-use-default-member-init,modernize-use-default-member-init)
   checksum_algorithm_type checksum_algorithm_;
   post_header_length_container post_header_lengths_{};
+  std::uint32_t position_{0ULL};
 
   void process_event(const event &current_event);
 };

--- a/src/binsrv/event/unknown_post_header.hpp
+++ b/src/binsrv/event/unknown_post_header.hpp
@@ -5,13 +5,15 @@
 
 #include <cstddef>
 
+#include "binsrv/event/protocol_traits_fwd.hpp"
+
 #include "util/byte_span_fwd.hpp"
 
 namespace binsrv::event {
 
 class [[nodiscard]] unknown_post_header {
 public:
-  static constexpr std::size_t size_in_bytes{~static_cast<std::size_t>(0U)};
+  static constexpr std::size_t size_in_bytes{unspecified_post_header_length};
 
   // this class will be used as the first type of the event post header
   // variant, so it needs to be default constructible

--- a/src/easymysql/binlog.cpp
+++ b/src/easymysql/binlog.cpp
@@ -15,12 +15,6 @@
 
 #include "util/byte_span_fwd.hpp"
 
-namespace {
-
-constexpr std::uint64_t magic_binlog_offset{4ULL};
-
-} // anonymous namespace
-
 namespace easymysql {
 
 void binlog::rpl_deleter::operator()(void *ptr) const noexcept {
@@ -32,10 +26,11 @@ void binlog::rpl_deleter::operator()(void *ptr) const noexcept {
   }
 }
 
-binlog::binlog(connection &conn, std::uint32_t server_id)
-    : conn_{&conn}, impl_{new MYSQL_RPL{.file_name_length = 0U,
-                                        .file_name = nullptr,
-                                        .start_position = magic_binlog_offset,
+binlog::binlog(connection &conn, std::uint32_t server_id,
+               std::string_view file_name, std::uint64_t position)
+    : conn_{&conn}, impl_{new MYSQL_RPL{.file_name_length = file_name.size(),
+                                        .file_name = file_name.data(),
+                                        .start_position = position,
                                         .server_id = server_id,
                                         // TODO: consider adding (or-ing)
                                         // BINLOG_DUMP_NON_BLOCK and

--- a/src/easymysql/binlog.hpp
+++ b/src/easymysql/binlog.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <memory>
 #include <span>
+#include <string_view>
 
 #include "easymysql/connection_fwd.hpp"
 
@@ -33,7 +34,8 @@ public:
   util::const_byte_span fetch();
 
 private:
-  binlog(connection &conn, std::uint32_t server_id);
+  binlog(connection &conn, std::uint32_t server_id, std::string_view file_name,
+         std::uint64_t position);
 
   connection *conn_{nullptr};
   struct rpl_deleter {

--- a/src/easymysql/connection.cpp
+++ b/src/easymysql/connection.cpp
@@ -69,9 +69,11 @@ std::string_view connection::get_character_set_name() const noexcept {
   return {mysql_character_set_name(connection_deimpl::get_const_casted(impl_))};
 }
 
-binlog connection::create_binlog(std::uint32_t server_id) {
+binlog connection::create_binlog(std::uint32_t server_id,
+                                 std::string_view file_name,
+                                 std::uint64_t position) {
   assert(!is_empty());
-  return {*this, server_id};
+  return {*this, server_id, file_name, position};
 }
 
 void connection::execute_generic_query_noresult(std::string_view query) {

--- a/src/easymysql/connection.hpp
+++ b/src/easymysql/connection.hpp
@@ -38,7 +38,9 @@ public:
   [[nodiscard]] std::string_view get_server_connection_info() const noexcept;
   [[nodiscard]] std::string_view get_character_set_name() const noexcept;
 
-  [[nodiscard]] binlog create_binlog(std::uint32_t server_id);
+  [[nodiscard]] binlog create_binlog(std::uint32_t server_id,
+                                     std::string_view file_name,
+                                     std::uint64_t position);
   void execute_generic_query_noresult(std::string_view query);
 
 private:


### PR DESCRIPTION
'reader_context' class extended with stream position tracking. For individual events we now check whether 'next_event_position' is the same as current reader position plus 'event_size'.

It is now possible to explicitly specify binlog file name and position when creating an instance of the 'binlog' class via 'connection::create_binlog()' method in 'easymysql'.