### PR TITLE
Added initial version of the file_storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,10 @@ set(source_files
   src/binsrv/file_logger.hpp
   src/binsrv/file_logger.cpp
 
+  src/binsrv/filesystem_storage_fwd.hpp
+  src/binsrv/filesystem_storage.hpp
+  src/binsrv/filesystem_storage.cpp
+
   src/binsrv/log_severity_fwd.hpp
   src/binsrv/log_severity.hpp
 
@@ -144,6 +148,9 @@ set(source_files
   src/binsrv/master_config_fwd.hpp
   src/binsrv/master_config.hpp
   src/binsrv/master_config.cpp
+
+  src/binsrv/storage_config_fwd.hpp
+  src/binsrv/storage_config.hpp
 
   # various utility files
   src/util/byte_span_fwd.hpp

--- a/master_config.json
+++ b/master_config.json
@@ -8,5 +8,8 @@
     "port": 3306,
     "user": "root",
     "password": ""
+  },
+  "storage": {
+    "path": "./storage"
   }
 }

--- a/mtr/README
+++ b/mtr/README
@@ -1,0 +1,9 @@
+In order to test Binlog Server Utility using MySQL Test Run (MTR) do the
+following:
+1. Create a symbolic link in 'mysql-test/suites' (in the MySQL Server source
+   tree) pointing to 'mtr/binlog_streaming' (in this source tree).
+   ln -s <this_source_tree_path>/mtr/binlog_streaming \
+         <mysql_source_tree_path>/mysql-test/suites/binlog_streaming
+2. Set 'BINSRV' enviroment variable pointing to the 'binlog_server' binary
+   and run MTR.
+   BINSRV=<build_directory_path>/binlog_server ./mysql-test/mtr --suite=binlog_streaming

--- a/mtr/binlog_streaming/r/binsrv.result
+++ b/mtr/binlog_streaming/r/binsrv.result
@@ -1,0 +1,81 @@
+*** Flushing binary logs at the very beginning of the test.
+FLUSH BINARY LOGS;
+
+*** Determining the first fresh binary log name.
+
+*** Purging all binary logs before the first fresh one.
+PURGE BINARY LOGS TO '<FIRST_BINLOG>';
+
+*** Creating a simple table and filling it with some data.
+CREATE TABLE t1(id INT UNSIGNED NOT NULL AUTO_INCREMENT, PRIMARY KEY(id)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(DEFAULT);
+
+*** Flushing the first binary log and switching to the second one.
+FLUSH BINARY LOGS;
+
+*** Determining the second binary log name.
+
+*** Filling the table with some more data and dropping the table.
+INSERT INTO t1 VALUES(DEFAULT);
+DROP TABLE t1;
+
+*** Generating a configuration file in JSON format for the Binlog
+*** Server utility.
+SET @storage_path = '<BINSRV_STORAGE_PATH>';
+SET @log_path = '<BINSRV_LOG_PATH>';
+SET @delimiter_pos = INSTR(USER(), '@');
+SET @connection_user = SUBSTRING(USER(), 1, @delimiter_pos - 1);
+SET @connection_host = SUBSTRING(USER(), @delimiter_pos + 1);
+SET @connection_host = IF(@connection_host = 'localhost', '127.0.0.1', @connection_host);
+SET @binsrv_config_json = JSON_OBJECT(
+'logger', JSON_OBJECT(
+'level', 'trace',
+'file', @log_path
+),
+'connection', JSON_OBJECT(
+'host', @connection_host,
+'port', @@global.port,
+'user', @connection_user,
+'password', ''
+  ),
+'storage', JSON_OBJECT(
+'path', @storage_path
+)
+);
+
+*** Determining binlog file directory from the server.
+
+*** Creating a temporary directory <BINSRV_STORAGE_PATH> for storing
+*** binlog files downloaded via the Binlog Server utility.
+
+*** Executing the Binlog Server utility to download all binlog data
+*** from the server to the <BINSRV_STORAGE_PATH> directory (second
+*** binlog is still open / in use).
+
+*** Comparing server and downloaded versions of the first binlog file.
+
+*** Patching the server version of the second binlog file to clear the
+*** LOG_EVENT_BINLOG_IN_USE_F (currently in use) flag.
+
+*** Comparing server and downloaded versions of the second binlog file.
+
+*** Cleaning up the Binlog Server utility storage directory.
+
+*** FLUSHING the binlog one more time to make sure that the second one
+*** is no longer open.
+FLUSH BINARY LOGS;
+
+*** Executing the Binlog Server utility one more time (the second
+*** binlog is no longer open / in use).
+
+*** Comparing server and downloaded versions of the first binlog file
+*** one more time.
+
+*** Comparing server and downloaded versions of the second binlog file
+*** (without patching) one more time.
+
+*** Removing the Binlog Server utility storage directory.
+
+*** Removing the Binlog Server utility log file.
+
+*** Removing the Binlog Server utility configuration file.

--- a/mtr/binlog_streaming/t/binsrv.combinations
+++ b/mtr/binlog_streaming/t/binsrv.combinations
@@ -1,0 +1,5 @@
+[crc]
+binlog_checksum = CRC32
+
+[nocrc]
+binlog_checksum = NONE

--- a/mtr/binlog_streaming/t/binsrv.test
+++ b/mtr/binlog_streaming/t/binsrv.test
@@ -1,0 +1,182 @@
+# make sure that $BINSRV environment variable is set to the absolute path
+# of the Binlog Server utility before running this test
+if (!$BINSRV) {
+  --skip \$BINSRV environment variable must be set
+}
+
+# in case of --repeat=N, we need to start from a fresh binary log to make
+# this test deterministic
+--echo *** Flushing binary logs at the very beginning of the test.
+FLUSH BINARY LOGS;
+
+--echo
+--echo *** Determining the first fresh binary log name.
+--let $first_binlog = query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $first_binlog <FIRST_BINLOG>
+
+--echo
+--echo *** Purging all binary logs before the first fresh one.
+--replace_result $first_binlog <FIRST_BINLOG>
+eval PURGE BINARY LOGS TO '$first_binlog';
+
+--echo
+--echo *** Creating a simple table and filling it with some data.
+CREATE TABLE t1(id INT UNSIGNED NOT NULL AUTO_INCREMENT, PRIMARY KEY(id)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(DEFAULT);
+
+--echo
+--echo *** Flushing the first binary log and switching to the second one.
+FLUSH BINARY LOGS;
+
+--echo
+--echo *** Determining the second binary log name.
+--let $second_binlog = query_get_value(SHOW MASTER STATUS, File, 1)
+
+--echo
+--echo *** Filling the table with some more data and dropping the table.
+INSERT INTO t1 VALUES(DEFAULT);
+DROP TABLE t1;
+
+--echo
+--echo *** Generating a configuration file in JSON format for the Binlog
+--echo *** Server utility.
+--let $binsrv_storage_path = $MYSQL_TMP_DIR/storage
+--replace_result $binsrv_storage_path <BINSRV_STORAGE_PATH>
+eval SET @storage_path = '$binsrv_storage_path';
+
+--let $binsrv_log_path = $MYSQL_TMP_DIR/binsrv.log
+--replace_result $binsrv_log_path <BINSRV_LOG_PATH>
+eval SET @log_path = '$binsrv_log_path';
+
+SET @delimiter_pos = INSTR(USER(), '@');
+SET @connection_user = SUBSTRING(USER(), 1, @delimiter_pos - 1);
+SET @connection_host = SUBSTRING(USER(), @delimiter_pos + 1);
+SET @connection_host = IF(@connection_host = 'localhost', '127.0.0.1', @connection_host);
+
+eval SET @binsrv_config_json = JSON_OBJECT(
+  'logger', JSON_OBJECT(
+    'level', 'trace',
+    'file', @log_path
+  ),
+  'connection', JSON_OBJECT(
+     'host', @connection_host,
+     'port', @@global.port,
+     'user', @connection_user,
+     'password', ''
+  ),
+  'storage', JSON_OBJECT(
+     'path', @storage_path
+  )
+);
+
+--let $binsrv_config_file_path = $MYSQL_TMP_DIR/binsrv_config.json
+--let $write_var = `SELECT @binsrv_config_json`
+--let $write_to_file = $binsrv_config_file_path
+--source include/write_var_to_file.inc
+
+--echo
+--echo *** Determining binlog file directory from the server.
+--disable_query_log
+SET @path_separator = '/';
+--source include/check_windows.inc
+if ($have_windows) {
+  SET @path_separator = '\\';
+}
+--let $binlog_base_dir = `SELECT LEFT(@@global.log_bin_basename, CHAR_LENGTH(@@global.log_bin_basename) - CHAR_LENGTH(SUBSTRING_INDEX(@@global.log_bin_basename, @path_separator, -1)))`
+--enable_query_log
+
+
+--echo
+--echo *** Creating a temporary directory <BINSRV_STORAGE_PATH> for storing
+--echo *** binlog files downloaded via the Binlog Server utility.
+--mkdir $binsrv_storage_path
+
+--echo
+--echo *** Executing the Binlog Server utility to download all binlog data
+--echo *** from the server to the <BINSRV_STORAGE_PATH> directory (second
+--echo *** binlog is still open / in use).
+--exec $BINSRV $binsrv_config_file_path > /dev/null 2>&1
+
+# At this point we have 2 binlog files $first_binlog (already closed/rotedted
+# by the server) and $second_binlog (currently open).
+
+# The former can be compared as is.
+--echo
+--echo *** Comparing server and downloaded versions of the first binlog file.
+--diff_files $binlog_base_dir/$first_binlog $binsrv_storage_path/$first_binlog
+
+# Because the latter from the server is currently open for writing, it has one
+# additional bit (LOG_EVENT_BINLOG_IN_USE_F = 0x1) set in the flags field of the
+# common header section of the very first format description event.
+# The expected offset of this change is 21 (4 bytes for magic binlog header
+# "\xFEbin" + 17, the offset of the 'flags' field in the common header).
+# So, here we create a copy of the second binlog file, patch this byte and
+# perform diff on this patched copy.
+
+--echo
+--echo *** Patching the server version of the second binlog file to clear the
+--echo *** LOG_EVENT_BINLOG_IN_USE_F (currently in use) flag.
+--let PATCHED_BINLOG_FILE = $MYSQL_TMP_DIR/$second_binlog.patched
+--copy_file $binlog_base_dir/$second_binlog $PATCHED_BINLOG_FILE
+
+--perl
+  use strict;
+  use warnings;
+  use constant MAGIC_OFFSET => 21;
+  my $binlog_file_perl = $ENV{'PATCHED_BINLOG_FILE'};
+
+  open(my $fh, '+<:raw', $binlog_file_perl) or die "Failed to open file: $!";
+
+  seek($fh, MAGIC_OFFSET, 0);
+  my $byte;
+  read($fh, $byte, 1);
+
+  $byte = ord($byte) & 0xFE;
+
+  seek($fh, MAGIC_OFFSET, 0);
+  print $fh pack('C', $byte);
+
+  close($fh);
+EOF
+
+--echo
+--echo *** Comparing server and downloaded versions of the second binlog file.
+--diff_files $PATCHED_BINLOG_FILE $binsrv_storage_path/$second_binlog
+--remove_file $PATCHED_BINLOG_FILE
+
+--echo
+--echo *** Cleaning up the Binlog Server utility storage directory.
+--force-rmdir $binsrv_storage_path
+--mkdir $binsrv_storage_path
+
+--echo
+--echo *** FLUSHING the binlog one more time to make sure that the second one
+--echo *** is no longer open.
+FLUSH BINARY LOGS;
+
+--echo
+--echo *** Executing the Binlog Server utility one more time (the second
+--echo *** binlog is no longer open / in use).
+--exec $BINSRV $binsrv_config_file_path > /dev/null 2>&1
+
+--echo
+--echo *** Comparing server and downloaded versions of the first binlog file
+--echo *** one more time.
+--diff_files $binlog_base_dir/$first_binlog $binsrv_storage_path/$first_binlog
+
+--echo
+--echo *** Comparing server and downloaded versions of the second binlog file
+--echo *** (without patching) one more time.
+--diff_files $binlog_base_dir/$second_binlog $binsrv_storage_path/$second_binlog
+
+--echo
+--echo *** Removing the Binlog Server utility storage directory.
+--force-rmdir $binsrv_storage_path
+
+--echo
+--echo *** Removing the Binlog Server utility log file.
+--remove_file $binsrv_log_path
+
+--echo
+--echo *** Removing the Binlog Server utility configuration file.
+--remove_file $binsrv_config_file_path

--- a/src/binsrv/event/checksum_algorithm_type.hpp
+++ b/src/binsrv/event/checksum_algorithm_type.hpp
@@ -12,7 +12,7 @@ namespace binsrv::event {
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 // Checksum algorithm type codes copied from
-// https://github.com/mysql/mysql-server/blob/mysql-8.0.35/libbinlogevents/include/binlog_event.h#L425
+// https://github.com/mysql/mysql-server/blob/mysql-8.0.36/libbinlogevents/include/binlog_event.h#L425
 // clang-format off
 #define BINSRV_CHECKSUM_ALGORITHM_TYPE_XY_SEQUENCE() \
   BINSRV_CHECKSUM_ALGORITHM_TYPE_XY_MACRO(off  ,  0), \

--- a/src/binsrv/event/code_type.hpp
+++ b/src/binsrv/event/code_type.hpp
@@ -12,7 +12,7 @@ namespace binsrv::event {
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 // Event type codes copied from
-// https://github.com/mysql/mysql-server/blob/mysql-8.0.35/libbinlogevents/include/binlog_event.h#L274
+// https://github.com/mysql/mysql-server/blob/mysql-8.0.36/libbinlogevents/include/binlog_event.h#L274
 // clang-format off
 #define BINSRV_EVENT_CODE_TYPE_XY_SEQUENCE() \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(unknown            ,  0), \

--- a/src/binsrv/event/common_header.cpp
+++ b/src/binsrv/event/common_header.cpp
@@ -24,7 +24,7 @@ common_header::common_header(util::const_byte_span portion) {
   // TODO: rework with direct member initialization
 
   /*
-    https://github.com/mysql/mysql-server/blob/mysql-8.0.35/libbinlogevents/src/binlog_event.cpp#L197
+    https://github.com/mysql/mysql-server/blob/mysql-8.0.36/libbinlogevents/src/binlog_event.cpp#L197
 
     The first 19 bytes in the header is as follows:
       +============================================+

--- a/src/binsrv/event/flag_type.hpp
+++ b/src/binsrv/event/flag_type.hpp
@@ -14,9 +14,17 @@ namespace binsrv::event {
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 // Event flags copied from
-// https://github.com/mysql/mysql-server/blob/mysql-8.0.35/sql/log_event.h#L246
+// https://github.com/mysql/mysql-server/blob/mysql-8.0.36/sql/log_event.h#L246
+// 'binlog_in_use' flag is copied from
+// https://github.com/mysql/mysql-server/blob/mysql-8.0.36/libbinlogevents/include/binlog_event.h#L269
+// This flag is used as a marker in the common header section of the very
+// first format description event that this particular binlog is currently in
+// use. It us cleared(rewritten) by the server when the binary log is
+// closed).
+// Events received via network stream should never have this flag set.
 // clang-format off
 #define BINSRV_EVENT_FLAG_TYPE_XY_SEQUENCE() \
+  BINSRV_EVENT_FLAG_TYPE_XY_MACRO(binlog_in_use  , 0x001U), \
   BINSRV_EVENT_FLAG_TYPE_XY_MACRO(thread_specific, 0x004U), \
   BINSRV_EVENT_FLAG_TYPE_XY_MACRO(suppress_use   , 0x008U), \
   BINSRV_EVENT_FLAG_TYPE_XY_MACRO(artificial     , 0x020U), \

--- a/src/binsrv/event/format_description_post_header_impl.cpp
+++ b/src/binsrv/event/format_description_post_header_impl.cpp
@@ -23,7 +23,7 @@ generic_post_header_impl<code_type::format_description>::
   // TODO: rework with direct member initialization
 
   /*
-    https://github.com/mysql/mysql-server/blob/mysql-8.0.35/libbinlogevents/include/control_events.h#L286
+    https://github.com/mysql/mysql-server/blob/mysql-8.0.36/libbinlogevents/include/control_events.h#L286
 
     +=====================================+
     | event  | binlog_version   19 : 2    | = 4
@@ -84,7 +84,7 @@ generic_post_header_impl<code_type::format_description>::get_server_version()
   auto result{util::as_string_view(server_version_)};
   auto position{result.find('\0')};
   if (position != std::string_view::npos) {
-    result.remove_suffix(result.size() - position);
+    result.remove_suffix(std::size(result) - position);
   }
   return result;
 }

--- a/src/binsrv/event/protocol_traits_fwd.hpp
+++ b/src/binsrv/event/protocol_traits_fwd.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <string_view>
 
 namespace binsrv::event {
 
@@ -14,6 +15,9 @@ inline constexpr std::size_t default_common_header_length{19U};
 inline constexpr std::size_t unspecified_post_header_length{
     std::numeric_limits<std::size_t>::max()};
 
+// https://github.com/mysql/mysql-server/blob/trunk/sql/log_event.h#L211
+// 4 bytes which all binlogs should begin with
+inline constexpr std::string_view magic_binlog_payload{"\xFE\x62\x69\x6E"};
 inline constexpr std::uint64_t magic_binlog_offset{4ULL};
 
 } // namespace binsrv::event

--- a/src/binsrv/event/reader_context.cpp
+++ b/src/binsrv/event/reader_context.cpp
@@ -54,6 +54,15 @@ void reader_context::process_event(const event &current_event) {
           "unexpected next event position on the event common header");
     }
     if (code == code_type::rotate) {
+      // position in non-artificial rotate event post header must be equal to
+      // magic_binlog_offset (4)
+      if (current_event.get_post_header<code_type::rotate>()
+              .get_position_id_raw() != magic_binlog_offset) {
+        util::exception_location().raise<std::logic_error>(
+            "unexpected position in an non-artificial rotate event post "
+            "header");
+      }
+
       // normal (non-artificial) event is expected to be the last event in
       // binlog - so we reset the current position here
       position_ = 0U;

--- a/src/binsrv/event/rotate_body_impl.hpp
+++ b/src/binsrv/event/rotate_body_impl.hpp
@@ -20,7 +20,9 @@ public:
     return binlog_;
   }
 
-  [[nodiscard]] std::string_view get_binlog() noexcept { return {binlog_}; }
+  [[nodiscard]] std::string_view get_binlog() const noexcept {
+    return {binlog_};
+  }
 
 private:
   binlog_storage binlog_{};

--- a/src/binsrv/event/rotate_post_header_impl.cpp
+++ b/src/binsrv/event/rotate_post_header_impl.cpp
@@ -18,7 +18,7 @@ generic_post_header_impl<code_type::rotate>::generic_post_header_impl(
   // TODO: rework with direct member initialization
 
   /*
-    https://github.com/mysql/mysql-server/blob/mysql-8.0.35/libbinlogevents/include/control_events.h#L53
+    https://github.com/mysql/mysql-server/blob/mysql-8.0.36/libbinlogevents/include/control_events.h#L53
 
     <table>
     <caption>Post-Header for Rotate_event</caption>

--- a/src/binsrv/filesystem_storage.cpp
+++ b/src/binsrv/filesystem_storage.cpp
@@ -1,0 +1,118 @@
+#include "binsrv/filesystem_storage.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <ios>
+#include <stdexcept>
+#include <string_view>
+
+#include "binsrv/event/protocol_traits_fwd.hpp"
+
+#include "util/byte_span.hpp"
+#include "util/exception_location_helpers.hpp"
+
+namespace binsrv {
+
+filesystem_storage::filesystem_storage(std::string_view root_path)
+    : root_path_{root_path}, binlog_names_{}, ofs_{} {
+  if (!std::filesystem::exists(root_path_)) {
+    util::exception_location().raise<std::invalid_argument>(
+        "root path does not exist");
+  }
+  if (!std::filesystem::is_directory(root_path_)) {
+    util::exception_location().raise<std::invalid_argument>(
+        "root path is not a directory");
+  }
+
+  // TODO: convert this into reading directory content and extracting
+  //       binlog file name / position
+  if (!std::filesystem::is_empty(root_path_)) {
+    util::exception_location().raise<std::invalid_argument>(
+        "root path directory is not empty");
+  }
+}
+
+[[nodiscard]] bool
+filesystem_storage::check_binlog_name(std::string_view binlog_name) noexcept {
+  // TODO: parse binlog name into "base name" and "rotation number"
+  //       e.g. "binlog.000001" -> ("binlog", 1)
+
+  // currently checking only that the name does not include a filesystem
+  // separator
+  return binlog_name.find(std::filesystem::path::preferred_separator) ==
+         std::string_view::npos;
+}
+
+void filesystem_storage::open_binlog(std::string_view binlog_name) {
+  if (ofs_.is_open()) {
+    util::exception_location().raise<std::logic_error>(
+        "cannot create a binlog as the previous one has noot been closed");
+  }
+  if (!check_binlog_name(binlog_name)) {
+    util::exception_location().raise<std::invalid_argument>(
+        "cannot create a binlog with invalid file name");
+  }
+
+  std::filesystem::path current_file_path{root_path_};
+  current_file_path /= binlog_name;
+  // opening in binary mode with truncation
+  ofs_.open(current_file_path, std::ios_base::binary | std::ios_base::trunc);
+  if (!ofs_.is_open()) {
+    util::exception_location().raise<std::invalid_argument>(
+        "cannot create a binlog file");
+  }
+  if (!ofs_.write(std::data(event::magic_binlog_payload),
+                  static_cast<std::streamoff>(
+                      std::size(event::magic_binlog_payload)))) {
+    util::exception_location().raise<std::invalid_argument>(
+        "cannot write magic payload to the binlog");
+  }
+
+  binlog_names_.emplace_back(binlog_name);
+  append_to_binlog_index(binlog_name);
+}
+
+void filesystem_storage::write_event(util::const_byte_span event_data) {
+  // TODO: make sure that the data is properly written to the disk
+  //       use fsync() system call here
+
+  if (!ofs_.is_open()) {
+    util::exception_location().raise<std::logic_error>(
+        "cannot write to the binlog file as it has not been opened");
+  }
+  const auto event_data_sv = util::as_string_view(event_data);
+  if (!ofs_.write(std::data(event_data_sv),
+                  static_cast<std::streamoff>(std::size(event_data_sv)))) {
+    util::exception_location().raise<std::invalid_argument>(
+        "cannot write event data to the binlog");
+  }
+  // TODO: consider adding fsync() call here
+}
+void filesystem_storage::close_binlog() {
+  if (!ofs_.is_open()) {
+    util::exception_location().raise<std::logic_error>(
+        "cannot close the binlog file as it has not been opened");
+  }
+  ofs_.close();
+}
+
+void filesystem_storage::append_to_binlog_index(std::string_view binlog_name) {
+  std::filesystem::path index_path{root_path_};
+  index_path /= default_binlog_index_name;
+  // opening in text mode with appending
+  std::ofstream index_ofs{index_path, std::ios_base::app};
+  if (!index_ofs.is_open()) {
+    util::exception_location().raise<std::invalid_argument>(
+        "cannot open binlog index file");
+  }
+  std::filesystem::path binlog_path{"./"};
+  binlog_path /= binlog_name;
+
+  index_ofs << binlog_path.generic_string() << '\n';
+  if (!index_ofs) {
+    util::exception_location().raise<std::invalid_argument>(
+        "cannot append to the binlog index file");
+  }
+}
+
+} // namespace binsrv

--- a/src/binsrv/filesystem_storage.hpp
+++ b/src/binsrv/filesystem_storage.hpp
@@ -1,0 +1,53 @@
+#ifndef BINSRV_FILESYSTEM_STORAGE_HPP
+#define BINSRV_FILESYSTEM_STORAGE_HPP
+
+#include "binsrv/filesystem_storage_fwd.hpp" // IWYU pragma: export
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "util/byte_span_fwd.hpp"
+
+namespace binsrv {
+
+class [[nodiscard]] filesystem_storage {
+public:
+  static constexpr std::string_view default_binlog_index_name{"binlog.index"};
+
+  explicit filesystem_storage(std::string_view root_path);
+
+  filesystem_storage(const filesystem_storage &) = delete;
+  filesystem_storage &operator=(const filesystem_storage &) = delete;
+  filesystem_storage(filesystem_storage &&) = delete;
+  filesystem_storage &operator=(filesystem_storage &&) = delete;
+
+  // desctuctor is explicitly defined as default here to complete the rule of 5
+  ~filesystem_storage() = default;
+
+  [[nodiscard]] const std::filesystem::path &get_root_path() const noexcept {
+    return root_path_;
+  }
+
+  [[nodiscard]] static bool
+  check_binlog_name(std::string_view binlog_name) noexcept;
+
+  void open_binlog(std::string_view binlog_name);
+  void write_event(util::const_byte_span event_data);
+  void close_binlog();
+
+private:
+  std::filesystem::path root_path_;
+
+  using binlog_name_container = std::vector<std::string>;
+  binlog_name_container binlog_names_;
+  std::ofstream ofs_;
+
+  void append_to_binlog_index(std::string_view binlog_name);
+};
+
+} // namespace binsrv
+
+#endif // BINSRV_FILESYSTEM_STORAGE_HPP

--- a/src/binsrv/filesystem_storage_fwd.hpp
+++ b/src/binsrv/filesystem_storage_fwd.hpp
@@ -1,0 +1,10 @@
+#ifndef BINSRV_FILESYSTEM_STORAGE_FWD_HPP
+#define BINSRV_FILESYSTEM_STORAGE_FWD_HPP
+
+namespace binsrv {
+
+class filesystem_storage;
+
+} // namespace binsrv
+
+#endif // BINSRV_FILESYSTEM_STORAGE_FWD_HPP

--- a/src/binsrv/master_config.cpp
+++ b/src/binsrv/master_config.cpp
@@ -11,7 +11,7 @@
 #include <boost/json/parse.hpp>
 #include <boost/json/src.hpp> // IWYU pragma: keep
 
-// Needed for log_template's operator <<
+// Needed for log_severity's operator <<
 #include "binsrv/log_severity.hpp" // IWYU pragma: keep
 
 #include "util/command_line_helpers_fwd.hpp"

--- a/src/binsrv/master_config.hpp
+++ b/src/binsrv/master_config.hpp
@@ -4,6 +4,7 @@
 #include "binsrv/master_config_fwd.hpp" // IWYU pragma: export
 
 #include "binsrv/logger_config.hpp" // IWYU pragma: export
+#include "binsrv/storage_config.hpp" // IWYU pragma: export
 
 #include "easymysql/connection_config.hpp" // IWYU pragma: export
 
@@ -17,7 +18,8 @@ private:
   using impl_type = util::nv_tuple<
       // clang-format off
       util::nv<"logger"    , logger_config>,
-      util::nv<"connection", easymysql::connection_config>
+      util::nv<"connection", easymysql::connection_config>,
+      util::nv<"storage"   , storage_config>
       // clang-format on
       >;
 

--- a/src/binsrv/storage_config.hpp
+++ b/src/binsrv/storage_config.hpp
@@ -1,0 +1,21 @@
+#ifndef BINSRV_STORAGE_CONFIG_HPP
+#define BINSRV_STORAGE_CONFIG_HPP
+
+#include "binsrv/storage_config_fwd.hpp" // IWYU pragma: export
+
+#include <string>
+
+#include "util/nv_tuple.hpp"
+
+namespace binsrv {
+
+// clang-format off
+struct [[nodiscard]] storage_config
+    : util::nv_tuple<
+          util::nv<"path", std::string>
+      > {};
+// clang-format on
+
+} // namespace binsrv
+
+#endif // BINSRV_STORAGE_CONFIG_HPP

--- a/src/binsrv/storage_config_fwd.hpp
+++ b/src/binsrv/storage_config_fwd.hpp
@@ -1,0 +1,10 @@
+#ifndef BINSRV_STORAGE_CONFIG_FWD_HPP
+#define BINSRV_STORAGE_CONFIG_FWD_HPP
+
+namespace binsrv {
+
+struct storage_config;
+
+} // namespace binsrv
+
+#endif // BINSRV_STORAGE_CONFIG_FWD_HPP

--- a/src/easymysql/binlog.cpp
+++ b/src/easymysql/binlog.cpp
@@ -28,21 +28,22 @@ void binlog::rpl_deleter::operator()(void *ptr) const noexcept {
 
 binlog::binlog(connection &conn, std::uint32_t server_id,
                std::string_view file_name, std::uint64_t position)
-    : conn_{&conn}, impl_{new MYSQL_RPL{.file_name_length = file_name.size(),
-                                        .file_name = file_name.data(),
-                                        .start_position = position,
-                                        .server_id = server_id,
-                                        // TODO: consider adding (or-ing)
-                                        // BINLOG_DUMP_NON_BLOCK and
-                                        // MYSQL_RPL_SKIP_HEARTBEAT to flags
-                                        .flags = 0U,
-                                        .gtid_set_encoded_size = 0U,
-                                        .fix_gtid_set = nullptr,
-                                        .gtid_set_arg = nullptr,
-                                        .size = 0U,
-                                        .buffer = nullptr
+    : conn_{&conn},
+      impl_{new MYSQL_RPL{.file_name_length = std::size(file_name),
+                          .file_name = std::data(file_name),
+                          .start_position = position,
+                          .server_id = server_id,
+                          // TODO: consider adding (or-ing)
+                          // BINLOG_DUMP_NON_BLOCK and
+                          // MYSQL_RPL_SKIP_HEARTBEAT to flags
+                          .flags = 0U,
+                          .gtid_set_encoded_size = 0U,
+                          .fix_gtid_set = nullptr,
+                          .gtid_set_arg = nullptr,
+                          .size = 0U,
+                          .buffer = nullptr
 
-                    }} {
+      }} {
   assert(!conn.is_empty());
 
   static constexpr std::string_view crc_query{

--- a/src/util/byte_span.hpp
+++ b/src/util/byte_span.hpp
@@ -8,12 +8,14 @@ namespace util {
 
 inline std::string_view as_string_view(byte_span portion) noexcept {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  return {reinterpret_cast<const char *>(portion.data()), portion.size()};
+  return {reinterpret_cast<const char *>(std::data(portion)),
+          std::size(portion)};
 }
 
 inline std::string_view as_string_view(const_byte_span portion) noexcept {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  return {reinterpret_cast<const char *>(portion.data()), portion.size()};
+  return {reinterpret_cast<const char *>(std::data(portion)),
+          std::size(portion)};
 }
 
 } // namespace util

--- a/src/util/byte_span_extractors.hpp
+++ b/src/util/byte_span_extractors.hpp
@@ -3,9 +3,7 @@
 
 #include <array>
 #include <cassert>
-// probably a bug in IWYU: <concepts> is required by std::integral
-// TODO: check if the same bug exust in clang-17
-#include <concepts> // IWYU pragma: keep
+#include <concepts>
 #include <cstddef>
 #include <cstring>
 


### PR DESCRIPTION
Added the 'file_storage" class that helps to write events received from the MySQL Server to local binlog files. It automatically deals with writing magic binlog payloads ("\xFEbin") and maintaining binlog index file ("binlog.index"). At the moment, this class can start with only empty initial state.

Main configuration file extended with additional "storage" section, which currently has only one parameter "path", pointing to the location to which binlog files should be downloaded.

Main application extended with writing received binlog events into local files using the functionality of the 'file_storage' class.

Added additional flag 'binlog_in_use' to the 'binsrv::event::flag_type' enum which is used by the server to mark binlog files that are currently in use. This flag should never appear in events received on the client side.

'reader_context' class extended with additional check that position in non-artificial rotate event post header must always be equal to magic_binlog_offset (4).

Some '<container>.size()' calls changed to 'std::size(<container>)'. Some '<container>.data()' calls changed to 'std::data(<container>)'.

Added the very first MTR test case that tests Binlog Server Utility functionality. It instructs the MySQL Server to generate 2 binary log files. Then it executes the Binlog Server Utility to download them into a local file storage. And after that it compares the binlog files stored on the server with those downloaded via the utility.

Added instructions on how to integrate these tests with the MTR framework.

Links pointing to MySQL Source code fragments on GitHub updated to version 8.0.36.