### PR TITLE
Added support for resuming download to existing binlog storage

### DIFF
--- a/mtr/binlog_streaming/r/binsrv.result
+++ b/mtr/binlog_streaming/r/binsrv.result
@@ -15,9 +15,8 @@ FLUSH BINARY LOGS;
 
 *** Determining the second binary log name.
 
-*** Filling the table with some more data and dropping the table.
+*** Filling the table with some more data.
 INSERT INTO t1 VALUES(DEFAULT);
-DROP TABLE t1;
 
 *** Generating a configuration file in JSON format for the Binlog
 *** Server utility.
@@ -59,14 +58,17 @@ SET @binsrv_config_json = JSON_OBJECT(
 
 *** Comparing server and downloaded versions of the second binlog file.
 
-*** Cleaning up the Binlog Server utility storage directory.
+*** Filling the table with some more data and dropping the table.
+INSERT INTO t1 VALUES(DEFAULT);
+DROP TABLE t1;
 
 *** FLUSHING the binlog one more time to make sure that the second one
 *** is no longer open.
 FLUSH BINARY LOGS;
 
 *** Executing the Binlog Server utility one more time (the second
-*** binlog is no longer open / in use).
+*** binlog is no longer open / in use). Here we should also continue
+*** streaming binlog events from the last saved position.
 
 *** Comparing server and downloaded versions of the first binlog file
 *** one more time.

--- a/mtr/binlog_streaming/t/binsrv.test
+++ b/mtr/binlog_streaming/t/binsrv.test
@@ -33,9 +33,8 @@ FLUSH BINARY LOGS;
 --let $second_binlog = query_get_value(SHOW MASTER STATUS, File, 1)
 
 --echo
---echo *** Filling the table with some more data and dropping the table.
+--echo *** Filling the table with some more data.
 INSERT INTO t1 VALUES(DEFAULT);
-DROP TABLE t1;
 
 --echo
 --echo *** Generating a configuration file in JSON format for the Binlog
@@ -145,9 +144,9 @@ EOF
 --remove_file $PATCHED_BINLOG_FILE
 
 --echo
---echo *** Cleaning up the Binlog Server utility storage directory.
---force-rmdir $binsrv_storage_path
---mkdir $binsrv_storage_path
+--echo *** Filling the table with some more data and dropping the table.
+INSERT INTO t1 VALUES(DEFAULT);
+DROP TABLE t1;
 
 --echo
 --echo *** FLUSHING the binlog one more time to make sure that the second one
@@ -156,7 +155,8 @@ FLUSH BINARY LOGS;
 
 --echo
 --echo *** Executing the Binlog Server utility one more time (the second
---echo *** binlog is no longer open / in use).
+--echo *** binlog is no longer open / in use). Here we should also continue
+--echo *** streaming binlog events from the last saved position.
 --exec $BINSRV $binsrv_config_file_path > /dev/null 2>&1
 
 --echo

--- a/src/binsrv/event/reader_context.hpp
+++ b/src/binsrv/event/reader_context.hpp
@@ -31,7 +31,7 @@ private:
   // NOLINTNEXTLINE(cppcoreguidelines-use-default-member-init,modernize-use-default-member-init)
   checksum_algorithm_type checksum_algorithm_;
   post_header_length_container post_header_lengths_{};
-  std::uint32_t position_{0ULL};
+  std::uint32_t position_{0U};
 
   void process_event(const event &current_event);
 };

--- a/src/binsrv/filesystem_storage.cpp
+++ b/src/binsrv/filesystem_storage.cpp
@@ -1,10 +1,14 @@
 #include "binsrv/filesystem_storage.hpp"
 
+#include <algorithm>
+#include <cstddef>
 #include <filesystem>
 #include <fstream>
 #include <ios>
 #include <stdexcept>
+#include <string>
 #include <string_view>
+#include <utility>
 
 #include "binsrv/event/protocol_traits_fwd.hpp"
 
@@ -15,6 +19,7 @@ namespace binsrv {
 
 filesystem_storage::filesystem_storage(std::string_view root_path)
     : root_path_{root_path}, binlog_names_{}, ofs_{} {
+  // TODO: switch to utf8 file names
   if (!std::filesystem::exists(root_path_)) {
     util::exception_location().raise<std::invalid_argument>(
         "root path does not exist");
@@ -24,11 +29,18 @@ filesystem_storage::filesystem_storage(std::string_view root_path)
         "root path is not a directory");
   }
 
-  // TODO: convert this into reading directory content and extracting
-  //       binlog file name / position
-  if (!std::filesystem::is_empty(root_path_)) {
-    util::exception_location().raise<std::invalid_argument>(
-        "root path directory is not empty");
+  const auto index_path = get_index_path();
+  if (!std::filesystem::exists(index_path)) {
+    if (!std::filesystem::is_empty(root_path_)) {
+      util::exception_location().raise<std::invalid_argument>(
+          "root path directory does not contain the binlog index file and is "
+          "not empty");
+    }
+  } else {
+    load_binlog_index(index_path);
+  }
+  if (!binlog_names_.empty()) {
+    position_ = std::filesystem::file_size(root_path_ / binlog_names_.back());
   }
 }
 
@@ -55,27 +67,37 @@ void filesystem_storage::open_binlog(std::string_view binlog_name) {
 
   std::filesystem::path current_file_path{root_path_};
   current_file_path /= binlog_name;
-  // opening in binary mode with truncation
-  ofs_.open(current_file_path, std::ios_base::binary | std::ios_base::trunc);
+
+  const bool is_appending{position_ != 0ULL};
+  // opening in binary mode with appending either appending or truncating
+  // depending on whether the storage was initialized on a non-empty
+  // directory or not
+  const auto mode{std::ios_base::binary |
+                  (is_appending ? std::ios_base::app : std::ios_base::trunc)};
+  ofs_.open(current_file_path, mode);
   if (!ofs_.is_open()) {
     util::exception_location().raise<std::invalid_argument>(
         "cannot create a binlog file");
   }
-  if (!ofs_.write(std::data(event::magic_binlog_payload),
-                  static_cast<std::streamoff>(
-                      std::size(event::magic_binlog_payload)))) {
-    util::exception_location().raise<std::invalid_argument>(
-        "cannot write magic payload to the binlog");
+  // writing the magic binlog footprint only if this is a newly
+  // created file
+  if (!is_appending) {
+    if (!ofs_.write(std::data(event::magic_binlog_payload),
+                    static_cast<std::streamoff>(
+                        std::size(event::magic_binlog_payload)))) {
+      util::exception_location().raise<std::invalid_argument>(
+          "cannot write magic payload to the binlog");
+    }
   }
 
-  binlog_names_.emplace_back(binlog_name);
-  append_to_binlog_index(binlog_name);
+  if (!is_appending) {
+    binlog_names_.emplace_back(binlog_name);
+    append_to_binlog_index(binlog_name);
+    position_ = event::magic_binlog_offset;
+  }
 }
 
 void filesystem_storage::write_event(util::const_byte_span event_data) {
-  // TODO: make sure that the data is properly written to the disk
-  //       use fsync() system call here
-
   if (!ofs_.is_open()) {
     util::exception_location().raise<std::logic_error>(
         "cannot write to the binlog file as it has not been opened");
@@ -86,7 +108,9 @@ void filesystem_storage::write_event(util::const_byte_span event_data) {
     util::exception_location().raise<std::invalid_argument>(
         "cannot write event data to the binlog");
   }
-  // TODO: consider adding fsync() call here
+  position_ += std::size(event_data);
+  // TODO: make sure that the data is properly written to the disk
+  //       use fsync() system call here
 }
 void filesystem_storage::close_binlog() {
   if (!ofs_.is_open()) {
@@ -94,18 +118,98 @@ void filesystem_storage::close_binlog() {
         "cannot close the binlog file as it has not been opened");
   }
   ofs_.close();
+  position_ = 0ULL;
+}
+
+[[nodiscard]] std::filesystem::path filesystem_storage::get_index_path() const {
+  auto result{root_path_};
+  result /= default_binlog_index_name;
+  return result;
+}
+
+void filesystem_storage::load_binlog_index(
+    const std::filesystem::path &index_path) {
+  if (!std::filesystem::is_regular_file(index_path)) {
+    util::exception_location().raise<std::invalid_argument>(
+        "the binlog index file is not a regular file");
+  }
+  // opening in text mode
+  std::ifstream index_ifs{index_path};
+  if (!index_ifs.is_open()) {
+    util::exception_location().raise<std::invalid_argument>(
+        "cannot open the binlog index file for reading");
+  }
+  std::string current_line;
+  while (std::getline(index_ifs, current_line)) {
+    if (current_line.empty()) {
+      continue;
+    }
+    const std::filesystem::path current_binlog_path{current_line};
+    if (current_binlog_path.parent_path() != default_binlog_index_entry_path) {
+      util::exception_location().raise<std::invalid_argument>(
+          "binlog index contains an entry that has an invalid path");
+    }
+    auto current_binlog_name{current_binlog_path.filename().string()};
+
+    if (current_binlog_name == default_binlog_index_name) {
+      util::exception_location().raise<std::invalid_argument>(
+          "binlog index contains a reference to the binlog index file name");
+    }
+    if (!check_binlog_name(current_binlog_name)) {
+      util::exception_location().raise<std::invalid_argument>(
+          "binlog index contains a reference a binlog file with invalid "
+          "name");
+    }
+    if (std::ranges::find(binlog_names_, current_binlog_name) !=
+        std::end(binlog_names_)) {
+      util::exception_location().raise<std::invalid_argument>(
+          "binlog index contains a duplicate entry");
+    }
+    binlog_names_.emplace_back(std::move(current_binlog_name));
+  }
+
+  std::size_t known_entries{0U};
+  for (auto const &dir_entry :
+       std::filesystem::directory_iterator{root_path_}) {
+    if (!dir_entry.is_regular_file()) {
+      util::exception_location().raise<std::invalid_argument>(
+          "filesystem storage directory contains an entry that is not a "
+          "regular file");
+    }
+    // TODO: check permissions here
+    const auto &dir_entry_path = dir_entry.path();
+    const auto dir_entry_filename = dir_entry_path.filename().string();
+
+    if (dir_entry_filename == default_binlog_index_name) {
+      continue;
+    }
+    if (std::ranges::find(binlog_names_, dir_entry_filename) ==
+        std::end(binlog_names_)) {
+      util::exception_location().raise<std::invalid_argument>(
+          "filesystem storage directory contains an entry that is not "
+          "referenced in the binlog index file");
+    }
+    ++known_entries;
+  }
+
+  if (known_entries != binlog_names_.size()) {
+    util::exception_location().raise<std::invalid_argument>(
+        "binlog index contains a reference to a non-existing file");
+  }
+
+  // TODO: add integrity checks (parsing + checksumming) for the binlog
+  //       files in the index
 }
 
 void filesystem_storage::append_to_binlog_index(std::string_view binlog_name) {
-  std::filesystem::path index_path{root_path_};
-  index_path /= default_binlog_index_name;
+  const auto index_path = get_index_path();
   // opening in text mode with appending
   std::ofstream index_ofs{index_path, std::ios_base::app};
   if (!index_ofs.is_open()) {
     util::exception_location().raise<std::invalid_argument>(
-        "cannot open binlog index file");
+        "cannot open binlog index file for updating");
   }
-  std::filesystem::path binlog_path{"./"};
+  std::filesystem::path binlog_path{default_binlog_index_entry_path};
   binlog_path /= binlog_name;
 
   index_ofs << binlog_path.generic_string() << '\n';

--- a/src/binsrv/filesystem_storage.hpp
+++ b/src/binsrv/filesystem_storage.hpp
@@ -16,6 +16,7 @@ namespace binsrv {
 class [[nodiscard]] filesystem_storage {
 public:
   static constexpr std::string_view default_binlog_index_name{"binlog.index"};
+  static constexpr std::string_view default_binlog_index_entry_path{"."};
 
   explicit filesystem_storage(std::string_view root_path);
 
@@ -29,6 +30,12 @@ public:
 
   [[nodiscard]] const std::filesystem::path &get_root_path() const noexcept {
     return root_path_;
+  }
+  [[nodiscard]] std::string_view get_binlog_name() const noexcept {
+    return binlog_names_.empty() ? std::string_view{} : binlog_names_.back();
+  }
+  [[nodiscard]] std::uint64_t get_position() const noexcept {
+    return position_;
   }
 
   [[nodiscard]] static bool
@@ -44,7 +51,10 @@ private:
   using binlog_name_container = std::vector<std::string>;
   binlog_name_container binlog_names_;
   std::ofstream ofs_;
+  std::uint64_t position_{0ULL};
 
+  [[nodiscard]] std::filesystem::path get_index_path() const;
+  void load_binlog_index(const std::filesystem::path &index_path);
   void append_to_binlog_index(std::string_view binlog_name);
 };
 

--- a/src/binsrv/master_config.cpp
+++ b/src/binsrv/master_config.cpp
@@ -35,7 +35,7 @@ master_config::master_config(std::string_view file_name) {
         "cannot open configuration file");
   }
   auto file_size = std::filesystem::file_size(file_path);
-  if (file_size == 0U) {
+  if (file_size == 0ULL) {
     util::exception_location().raise<std::invalid_argument>(
         "configuration file is empty");
   }

--- a/src/easymysql/connection.cpp
+++ b/src/easymysql/connection.cpp
@@ -79,7 +79,7 @@ binlog connection::create_binlog(std::uint32_t server_id,
 void connection::execute_generic_query_noresult(std::string_view query) {
   assert(!is_empty());
   auto *casted_impl = connection_deimpl::get(impl_);
-  if (mysql_real_query(casted_impl, std::data(query), std::size(query)) != 0U) {
+  if (mysql_real_query(casted_impl, std::data(query), std::size(query)) != 0) {
     raise_core_error_from_connection(*this);
   }
 }


### PR DESCRIPTION
'binsrv::filesystem_storage' now supports reading the content of the data directory upon initialization, analyzing its entries, compare them with the content of the binlog index file and setting last used binlog name / position as the result.

'binsrv::events::reader_context' class extended with ability to correctly process the stream of binlog events that starts not from the very beginning but from the specified position (binlog name / offset). In this case we expect an artificial RORATE event followed by a pseudo FDE (the one that has next event position equal to 0 and should not be written to the filesystem storage).

'binlog_streaming.binsrv' MTR test case now also resumes streaming binlog events to a file storage directory created at a previous run.