### PR TITLE
Implemented generic mechanism for printing data of parsed binlog events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,9 +114,11 @@ set(source_files
 
   src/binsrv/event/unknown_body_fwd.hpp
   src/binsrv/event/unknown_body.hpp
+  src/binsrv/event/unknown_body.cpp
 
   src/binsrv/event/unknown_post_header_fwd.hpp
   src/binsrv/event/unknown_post_header.hpp
+  src/binsrv/event/unknown_post_header.cpp
 
   # billog files
   src/binsrv/basic_logger_fwd.hpp

--- a/src/binsrv/event/checksum_algorithm_type.hpp
+++ b/src/binsrv/event/checksum_algorithm_type.hpp
@@ -35,10 +35,9 @@ inline std::string_view to_string_view(checksum_algorithm_type code) noexcept {
       BINSRV_CHECKSUM_ALGORITHM_TYPE_XY_SEQUENCE(),
       nv_pair{checksum_algorithm_type::delimiter, ""sv}};
 #undef BINSRV_CHECKSUM_ALGORITHM_TYPE_XY_MACRO
-  return std::ranges::find(labels,
-                           std::min(checksum_algorithm_type::delimiter, code),
-                           &nv_pair::first)
-      ->second;
+  // NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
+  const auto fnd{std::ranges::find(labels, code, &nv_pair::first)};
+  return fnd == std::end(labels) ? ""sv : fnd->second;
 }
 #undef BINSRV_CHECKSUM_ALGORITHM_TYPE_XY_SEQUENCE
 // NOLINTEND(cppcoreguidelines-macro-usage)

--- a/src/binsrv/event/code_type.hpp
+++ b/src/binsrv/event/code_type.hpp
@@ -67,9 +67,9 @@ inline std::string_view to_string_view(code_type code) noexcept {
   static constexpr std::array labels{BINSRV_EVENT_CODE_TYPE_XY_SEQUENCE(),
                                      nv_pair{code_type::delimiter, ""sv}};
 #undef BINSRV_EVENT_CODE_TYPE_XY_MACRO
-  return std::ranges::find(labels, std::min(code_type::delimiter, code),
-                           &nv_pair::first)
-      ->second;
+  // NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
+  const auto fnd{std::ranges::find(labels, code, &nv_pair::first)};
+  return fnd == std::end(labels) ? ""sv : fnd->second;
 }
 #undef BINSRV_EVENT_CODE_TYPE_XY_SEQUENCE
 // NOLINTEND(cppcoreguidelines-macro-usage)

--- a/src/binsrv/event/common_header.cpp
+++ b/src/binsrv/event/common_header.cpp
@@ -1,5 +1,6 @@
 #include "binsrv/event/common_header.hpp"
 
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -95,6 +96,16 @@ common_header::get_readable_type_code() const noexcept {
 
 [[nodiscard]] std::string common_header::get_readable_flags() const {
   return to_string(get_flags());
+}
+
+std::ostream &operator<<(std::ostream &output, const common_header &obj) {
+  return output << "ts: " << obj.get_readable_timestamp()
+                << ", type: " << obj.get_readable_type_code()
+                << ", server id: " << obj.get_server_id_raw()
+                << ", event size: " << obj.get_event_size_raw()
+                << ", next event position: "
+                << obj.get_next_event_position_raw()
+                << ", flags: " << obj.get_readable_flags();
 }
 
 } // namespace binsrv::event

--- a/src/binsrv/event/common_header_fwd.hpp
+++ b/src/binsrv/event/common_header_fwd.hpp
@@ -1,9 +1,13 @@
 #ifndef BINSRV_EVENT_COMMON_HEADER_FWD_HPP
 #define BINSRV_EVENT_COMMON_HEADER_FWD_HPP
 
+#include <iosfwd>
+
 namespace binsrv::event {
 
 class common_header;
+
+std::ostream &operator<<(std::ostream &output, const common_header &obj);
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/empty_body.cpp
+++ b/src/binsrv/event/empty_body.cpp
@@ -1,5 +1,6 @@
 #include "binsrv/event/empty_body.hpp"
 
+#include <iosfwd>
 #include <iterator>
 #include <stdexcept>
 
@@ -13,6 +14,10 @@ empty_body::empty_body(util::const_byte_span portion) {
     util::exception_location().raise<std::invalid_argument>(
         "invalid event empty body length");
   }
+}
+
+std::ostream &operator<<(std::ostream &output, const empty_body & /* obj */) {
+  return output;
 }
 
 } // namespace binsrv::event

--- a/src/binsrv/event/empty_body_fwd.hpp
+++ b/src/binsrv/event/empty_body_fwd.hpp
@@ -1,9 +1,13 @@
 #ifndef BINSRV_EVENT_EMPTY_BODY_FWD_HPP
 #define BINSRV_EVENT_EMPTY_BODY_FWD_HPP
 
+#include <iosfwd>
+
 namespace binsrv::event {
 
 class empty_body;
+
+std::ostream &operator<<(std::ostream &output, const enpty_body &obj);
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/empty_post_header.cpp
+++ b/src/binsrv/event/empty_post_header.cpp
@@ -1,5 +1,6 @@
 #include "binsrv/event/empty_post_header.hpp"
 
+#include <iosfwd>
 #include <iterator>
 #include <stdexcept>
 
@@ -13,6 +14,11 @@ empty_post_header::empty_post_header(util::const_byte_span portion) {
     util::exception_location().raise<std::invalid_argument>(
         "invalid event empty post header length");
   }
+}
+
+std::ostream &operator<<(std::ostream &output,
+                         const empty_post_header & /* obj */) {
+  return output;
 }
 
 } // namespace binsrv::event

--- a/src/binsrv/event/empty_post_header_fwd.hpp
+++ b/src/binsrv/event/empty_post_header_fwd.hpp
@@ -1,9 +1,12 @@
 #ifndef BINSRV_EVENT_EMPTY_POST_HEADER_FWD_HPP
 #define BINSRV_EVENT_EMPTY_POST_HEADER_FWD_HPP
 
+#include <iosfwd>
 namespace binsrv::event {
 
 class empty_post_header;
+
+std::ostream &operator<<(std::ostream &output, const empty_post_header &obj);
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/event_fwd.hpp
+++ b/src/binsrv/event/event_fwd.hpp
@@ -1,9 +1,12 @@
 #ifndef BINSRV_EVENT_EVENT_FWD_HPP
 #define BINSRV_EVENT_EVENT_FWD_HPP
 
+#include <iosfwd>
 namespace binsrv::event {
 
 class event;
+
+std::ostream &operator<<(std::ostream &output, const event &obj);
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/flag_type.hpp
+++ b/src/binsrv/event/flag_type.hpp
@@ -49,9 +49,9 @@ inline std::string_view to_string_view(flag_type code) noexcept {
   static constexpr std::array labels{BINSRV_EVENT_FLAG_TYPE_XY_SEQUENCE(),
                                      nv_pair{flag_type::delimiter, ""sv}};
 #undef BINSRV_EVENT_FLAG_TYPE_XY_MACRO
-  return std::ranges::find(labels, std::min(flag_type::delimiter, code),
-                           &nv_pair::first)
-      ->second;
+  // NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
+  const auto fnd{std::ranges::find(labels, code, &nv_pair::first)};
+  return fnd == std::end(labels) ? ""sv : fnd->second;
 }
 #undef BINSRV_EVENT_FLAG_TYPE_XY_SEQUENCE
 // NOLINTEND(cppcoreguidelines-macro-usage)

--- a/src/binsrv/event/footer.cpp
+++ b/src/binsrv/event/footer.cpp
@@ -1,9 +1,16 @@
 #include "binsrv/event/footer.hpp"
 
+#include <iomanip>
+#include <ios>
 #include <iterator>
+#include <ostream>
 #include <stdexcept>
 
+#include <boost/io_fwd.hpp>
+
 #include <boost/align/align_up.hpp>
+
+#include <boost/io/ios_state.hpp>
 
 #include "util/byte_span_extractors.hpp"
 #include "util/byte_span_fwd.hpp"
@@ -30,6 +37,14 @@ footer::footer(util::const_byte_span portion) {
 
   auto remainder = portion;
   util::extract_fixed_int_from_byte_span(remainder, crc_);
+}
+
+std::ostream &operator<<(std::ostream &output, const footer &obj) {
+  const boost::io::ios_flags_saver flag_saver(output);
+  const boost::io::ios_fill_saver fill_saver(output);
+  return output << "crc: " << std::hex << std::showbase << std::setfill('0')
+                << std::setw(sizeof(obj.get_crc_raw()) * 2)
+                << obj.get_crc_raw();
 }
 
 } // namespace binsrv::event

--- a/src/binsrv/event/footer_fwd.hpp
+++ b/src/binsrv/event/footer_fwd.hpp
@@ -1,9 +1,12 @@
 #ifndef BINSRV_EVENT_FOOTER_FWD_HPP
 #define BINSRV_EVENT_FOOTER_FWD_HPP
 
+#include <iosfwd>
 namespace binsrv::event {
 
 class footer;
+
+std::ostream &operator<<(std::ostream &output, const footer &obj);
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/format_description_body_impl.cpp
+++ b/src/binsrv/event/format_description_body_impl.cpp
@@ -1,6 +1,7 @@
 #include "binsrv/event/format_description_body_impl.hpp"
 
 #include <iterator>
+#include <ostream>
 #include <stdexcept>
 #include <string_view>
 
@@ -49,6 +50,13 @@ generic_body_impl<code_type::format_description>::generic_body_impl(
     code_type::format_description>::get_readable_checksum_algorithm()
     const noexcept {
   return to_string_view(get_checksum_algorithm());
+}
+
+std::ostream &
+operator<<(std::ostream &output,
+           const generic_body_impl<code_type::format_description> &obj) {
+  return output << "checksum algorithm: "
+                << obj.get_readable_checksum_algorithm();
 }
 
 } // namespace binsrv::event

--- a/src/binsrv/event/format_description_body_impl_fwd.hpp
+++ b/src/binsrv/event/format_description_body_impl_fwd.hpp
@@ -1,12 +1,18 @@
 #ifndef BINSRV_EVENT_FORMAT_DESCRIPTION_BODY_IMPL_FWD_HPP
 #define BINSRV_EVENT_FORMAT_DESCRIPTION_BODY_IMPL_FWD_HPP
 
+#include <iosfwd>
+
 #include "binsrv/event/code_type.hpp"
 #include "binsrv/event/generic_body_fwd.hpp"
 
 namespace binsrv::event {
 
 template <> class generic_body_impl<code_type::format_description>;
+
+std::ostream &
+operator<<(std::ostream &output,
+           const generic_body_impl<code_type::format_description> &obj);
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/format_description_post_header_impl.cpp
+++ b/src/binsrv/event/format_description_post_header_impl.cpp
@@ -1,5 +1,6 @@
 #include "binsrv/event/format_description_post_header_impl.hpp"
 
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -11,6 +12,7 @@
 #include <boost/date_time/posix_time/time_formatters.hpp>
 
 #include "binsrv/event/code_type.hpp"
+#include "binsrv/event/protocol_traits.hpp"
 
 #include "util/byte_span.hpp"
 #include "util/byte_span_extractors.hpp"
@@ -93,6 +95,19 @@ generic_post_header_impl<code_type::format_description>::get_server_version()
     code_type::format_description>::get_readable_create_timestamp() const {
   return boost::posix_time::to_simple_string(
       boost::posix_time::from_time_t(get_create_timestamp()));
+}
+
+std::ostream &
+operator<<(std::ostream &output,
+           const generic_post_header_impl<code_type::format_description> &obj) {
+  output << "binlog version: " << obj.get_binlog_version_raw()
+         << ", server version: " << obj.get_server_version()
+         << ", create timestamp: " << obj.get_readable_create_timestamp()
+         << ", common header length: " << obj.get_common_header_length()
+         << "\npost-header lengths: {\n";
+  print_post_header_lengths(output, obj.get_post_header_lengths_raw());
+  output << "\n}";
+  return output;
 }
 
 } // namespace binsrv::event

--- a/src/binsrv/event/format_description_post_header_impl_fwd.hpp
+++ b/src/binsrv/event/format_description_post_header_impl_fwd.hpp
@@ -1,12 +1,18 @@
 #ifndef BINSRV_EVENT_FORMAT_DESCRIPTION_POST_HEADER_IMPL_FWD_HPP
 #define BINSRV_EVENT_FORMAT_DESCRIPTION_POST_HEADER_IMPL_FWD_HPP
 
+#include <iosfwd>
+
 #include "binsrv/event/code_type.hpp"
 #include "binsrv/event/generic_post_header_fwd.hpp"
 
 namespace binsrv::event {
 
 template <> class generic_post_header_impl<code_type::format_description>;
+
+std::ostream &
+operator<<(std::ostream &output,
+           const generic_post_header_impl<code_type::format_description> &obj);
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/protocol_traits.hpp
+++ b/src/binsrv/event/protocol_traits.hpp
@@ -21,6 +21,10 @@ using post_header_length_container =
 get_post_header_length_for_code(const post_header_length_container &storage,
                                 code_type code) noexcept;
 
+std::ostream &
+print_post_header_lengths(std::ostream &output,
+                          const post_header_length_container &obj);
+
 void validate_post_header_lengths(
     const post_header_length_container &runtime,
     const post_header_length_container &hardcoded);

--- a/src/binsrv/event/reader_context.cpp
+++ b/src/binsrv/event/reader_context.cpp
@@ -45,8 +45,7 @@ void reader_context::process_event(const event &current_event) {
     }
 
     position_ = static_cast<std::uint32_t>(
-        current_event.get_post_header<code_type::rotate>()
-            .get_position_id_raw());
+        current_event.get_post_header<code_type::rotate>().get_position_raw());
   }
   if (!is_artificial && !is_pseudo) {
     // every non-artificial event must be preceded by the FDE
@@ -72,8 +71,8 @@ void reader_context::process_event(const event &current_event) {
   if (code == code_type::rotate && !is_artificial) {
     // position in non-artificial rotate event post header must be equal to
     // magic_binlog_offset (4)
-    if (current_event.get_post_header<code_type::rotate>()
-            .get_position_id_raw() != magic_binlog_offset) {
+    if (current_event.get_post_header<code_type::rotate>().get_position_raw() !=
+        magic_binlog_offset) {
       util::exception_location().raise<std::logic_error>(
           "unexpected position in an non-artificial rotate event post "
           "header");

--- a/src/binsrv/event/rotate_body_impl.cpp
+++ b/src/binsrv/event/rotate_body_impl.cpp
@@ -1,5 +1,7 @@
 #include "binsrv/event/rotate_body_impl.hpp"
 
+#include <ostream>
+
 #include "binsrv/event/code_type.hpp"
 
 #include "util/byte_span.hpp"
@@ -14,6 +16,11 @@ generic_body_impl<code_type::rotate>::generic_body_impl(
   // only one member for holding data of varying length
 
   binlog_.assign(util::as_string_view(portion));
+}
+
+std::ostream &operator<<(std::ostream &output,
+                         const generic_body_impl<code_type::rotate> &obj) {
+  return output << "binlog: " << obj.get_binlog();
 }
 
 } // namespace binsrv::event

--- a/src/binsrv/event/rotate_body_impl.hpp
+++ b/src/binsrv/event/rotate_body_impl.hpp
@@ -12,6 +12,8 @@ namespace binsrv::event {
 
 template <> class [[nodiscard]] generic_body_impl<code_type::rotate> {
 public:
+  // TODO: change this to a container with larger buffer for SBO to avoid
+  //       memory allocations (e.g. boost::container::small_vector)
   using binlog_storage = std::string;
 
   explicit generic_body_impl(util::const_byte_span portion);

--- a/src/binsrv/event/rotate_body_impl_fwd.hpp
+++ b/src/binsrv/event/rotate_body_impl_fwd.hpp
@@ -1,12 +1,17 @@
 #ifndef BINSRV_EVENT_ROTATE_BODY_IMPL_FWD_HPP
 #define BINSRV_EVENT_ROTATE_BODY_IMPL_FWD_HPP
 
+#include <iosfwd>
+
 #include "binsrv/event/code_type.hpp"
 #include "binsrv/event/generic_body_fwd.hpp"
 
 namespace binsrv::event {
 
 template <> class generic_body_impl<code_type::rotate>;
+
+std::ostream &operator<<(std::ostream &output,
+                         const generic_body_impl<code_type::rotate> &obj);
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/rotate_post_header_impl.cpp
+++ b/src/binsrv/event/rotate_post_header_impl.cpp
@@ -1,6 +1,7 @@
 #include "binsrv/event/rotate_post_header_impl.hpp"
 
 #include <iterator>
+#include <ostream>
 #include <stdexcept>
 
 #include <boost/align/align_up.hpp>
@@ -55,6 +56,12 @@ generic_post_header_impl<code_type::rotate>::generic_post_header_impl(
 
   auto remainder = portion;
   util::extract_fixed_int_from_byte_span(remainder, position_);
+}
+
+std::ostream &
+operator<<(std::ostream &output,
+           const generic_post_header_impl<code_type::rotate> &obj) {
+  return output << "position: " << obj.get_position_raw();
 }
 
 } // namespace binsrv::event

--- a/src/binsrv/event/rotate_post_header_impl.hpp
+++ b/src/binsrv/event/rotate_post_header_impl.hpp
@@ -16,7 +16,7 @@ public:
 
   explicit generic_post_header_impl(util::const_byte_span portion);
 
-  [[nodiscard]] std::uint64_t get_position_id_raw() const noexcept {
+  [[nodiscard]] std::uint64_t get_position_raw() const noexcept {
     return position_;
   }
 

--- a/src/binsrv/event/rotate_post_header_impl_fwd.hpp
+++ b/src/binsrv/event/rotate_post_header_impl_fwd.hpp
@@ -1,12 +1,18 @@
 #ifndef BINSRV_EVENT_ROTATE_POST_HEADER_IMPL_FWD_HPP
 #define BINSRV_EVENT_ROTATE_POST_HEADER_IMPL_FWD_HPP
 
+#include <iosfwd>
+
 #include "binsrv/event/code_type.hpp"
 #include "binsrv/event/generic_post_header_fwd.hpp"
 
 namespace binsrv::event {
 
 template <> class generic_post_header_impl<code_type::rotate>;
+
+std::ostream &
+operator<<(std::ostream &output,
+           const generic_post_header_impl<code_type::rotate> &obj);
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/unknown_body.cpp
+++ b/src/binsrv/event/unknown_body.cpp
@@ -1,0 +1,11 @@
+#include "binsrv/event/unknown_body.hpp"
+
+#include <iosfwd>
+
+namespace binsrv::event {
+
+std::ostream &operator<<(std::ostream &output, const unknown_body & /* obj */) {
+  return output;
+}
+
+} // namespace binsrv::event

--- a/src/binsrv/event/unknown_body_fwd.hpp
+++ b/src/binsrv/event/unknown_body_fwd.hpp
@@ -1,9 +1,12 @@
 #ifndef BINSRV_EVENT_UNKNOWN_BODY_FWD_HPP
 #define BINSRV_EVENT_UNKNOWN_BODY_FWD_HPP
 
+#include <iosfwd>
 namespace binsrv::event {
 
 class unknown_body;
+
+std::ostream &operator<<(std::ostream &output, const unknown_body &obj);
 
 } // namespace binsrv::event
 

--- a/src/binsrv/event/unknown_post_header.cpp
+++ b/src/binsrv/event/unknown_post_header.cpp
@@ -1,0 +1,12 @@
+#include "binsrv/event/unknown_post_header.hpp"
+
+#include <iosfwd>
+
+namespace binsrv::event {
+
+std::ostream &operator<<(std::ostream &output,
+                         const unknown_post_header & /* obj */) {
+  return output;
+}
+
+} // namespace binsrv::event

--- a/src/binsrv/event/unknown_post_header_fwd.hpp
+++ b/src/binsrv/event/unknown_post_header_fwd.hpp
@@ -1,9 +1,12 @@
 #ifndef BINSRV_EVENT_UNKNOWN_POST_HEADER_FWD_HPP
 #define BINSRV_EVENT_UNKNOWN_POST_HEADER_FWD_HPP
 
+#include <iosfwd>
 namespace binsrv::event {
 
 class unknown_post_header;
+
+std::ostream &operator<<(std::ostream &output, const unknown_post_header &obj);
 
 } // namespace binsrv::event
 


### PR DESCRIPTION
'binsrv::event::common_header' / 'binsrv::event::common_header' now support 'operator <<' to 'std::ostream'.

Each known 'binsrv::event::generic_body_impl<code_type::xxx>' / 'binsrv::event::generic_post_header_impl<code_type::xxx>' now support 'operator <<' to 'std::ostream'.

Implemented 'operator <<' to 'std::ostream' for the 'binsrv::event::event' class that uses corresponding 'operator <<' for common header and footer subcomponents and 'std::visit()' for variant-based post header and body.

Main application reworked with using 'operator <<' for logging received binlog events.

Fixed an issue with dereferencing end iterator when passing an unknown enum value to the 'to_string_view()' function for the following "smart" enums:
- binsrv::event::checksum_algorithm_type
- binsrv::event::code_type
- binsrv::event::flag_type

Fixed the name of the 'get_position_raw()' method in 'binsrv::event::generic_post_header_impl<code_type::rotate>' class (it was named 'get_position_id_raw()' by mistake).