### PR TITLE
Added replication section to main configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,9 @@ set(source_files
   src/easymysql/library_fwd.hpp
   src/easymysql/library.hpp
   src/easymysql/library.cpp
+
+  src/easymysql/replication_config_fwd.hpp
+  src/easymysql/replication_config.hpp
 )
 
 add_executable(binlog_server ${source_files})

--- a/main_config.json
+++ b/main_config.json
@@ -12,6 +12,10 @@
     "read_timeout": 60,
     "write_timeout": 60
   },
+  "replication": {
+    "server_id": 42,
+    "idle_time": 10
+  },
   "storage": {
     "uri": "file:///home/user/vault"
   }

--- a/mtr/binlog_streaming/t/binsrv.test
+++ b/mtr/binlog_streaming/t/binsrv.test
@@ -110,6 +110,10 @@ eval SET @binsrv_config_json = JSON_OBJECT(
      'read_timeout', 60,
      'write_timeout', 60
   ),
+  'replication', JSON_OBJECT(
+     'server_id', @@server_id + 1,
+     'idle_time', 10
+  ),
   'storage', JSON_OBJECT(
      'uri', @storage_uri
   )

--- a/src/binsrv/main_config.hpp
+++ b/src/binsrv/main_config.hpp
@@ -21,7 +21,8 @@
 #include "binsrv/logger_config.hpp"  // IWYU pragma: export
 #include "binsrv/storage_config.hpp" // IWYU pragma: export
 
-#include "easymysql/connection_config.hpp" // IWYU pragma: export
+#include "easymysql/connection_config.hpp"  // IWYU pragma: export
+#include "easymysql/replication_config.hpp" // IWYU pragma: export
 
 #include "util/command_line_helpers_fwd.hpp"
 #include "util/nv_tuple.hpp"
@@ -32,9 +33,10 @@ class [[nodiscard]] main_config {
 private:
   using impl_type = util::nv_tuple<
       // clang-format off
-      util::nv<"logger"    , logger_config>,
-      util::nv<"connection", easymysql::connection_config>,
-      util::nv<"storage"   , storage_config>
+      util::nv<"logger"     , logger_config>,
+      util::nv<"connection" , easymysql::connection_config>,
+      util::nv<"replication", easymysql::replication_config>,
+      util::nv<"storage"    , storage_config>
       // clang-format on
       >;
 

--- a/src/easymysql/replication_config.hpp
+++ b/src/easymysql/replication_config.hpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#ifndef EASYMYSQL_REPLICATION_CONFIG_HPP
+#define EASYMYSQL_REPLICATION_CONFIG_HPP
+
+#include "easymysql/replication_config_fwd.hpp" // IWYU pragma: export
+
+#include <cstdint>
+
+#include "util/nv_tuple.hpp"
+
+namespace easymysql {
+
+struct [[nodiscard]] replication_config
+    : util::nv_tuple<
+          // clang-format off
+          util::nv<"server_id", std::uint32_t>,
+          util::nv<"idle_time", std::uint32_t>
+          // clang-format on
+          > {};
+
+} // namespace easymysql
+
+#endif // EASYMYSQL_REPLICATION_CONFIG_HPP

--- a/src/easymysql/replication_config_fwd.hpp
+++ b/src/easymysql/replication_config_fwd.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#ifndef EASYMYSQL_REPLICATION_CONFIG_FWD_HPP
+#define EASYMYSQL_REPLICATION_CONFIG_FWD_HPP
+
+namespace easymysql {
+
+struct replication_config;
+
+} // namespace easymysql
+
+#endif // EASYMYSQL_REPLICATION_CONFIG_FWD_HPP


### PR DESCRIPTION
Added 'easymysql::replication_config' class with two fields:
* 'server_id' - the ID of the MySQL pseudo server that will be send to the server when switching connection to replication mode.
* 'idle_time' - the number of seconds the utility will wait between reconnection attempts.
Both parameters can be specified both in JSON configuration file and via command line arguments.
Sample JSON configuration file ('main_config.json') and 'binlog_streaming.binsrv' MTR test case updated correspondingly.

After this change the replication connection (after reading all available binlog events) will wait for '<connection.read_timeout>' seconds, then will close the connection and will wait for '<replication.idle_time>' seconds before trying to reconnect.

Logging of connection configuration info and replication configuration info moved from the 'main()' into separate functions:
* 'log_connection_config_info()'
* 'log_replication_info()'