### PR TITLE
Added CMake presets for Boost, AWS SDK C++ and main application

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -61,64 +61,33 @@ jobs:
         config:
         - {
             name: "GCC 13 Debug",
-            build_type: "Debug",
-            cc: "gcc-13",
-            cxx: "g++-13",
-            label: "Debug-gcc13",
+            label: "debug_gcc13",
             run_mtr: true
           }
         - {
             name: "GCC 13 RelWithDebInfo",
-            build_type: "RelWithDebInfo",
-            cc: "gcc-13",
-            cxx: "g++-13",
-            label: "RelWithDebInfo-gcc13",
+            label: "release_gcc13",
             run_mtr: true
           }
         - {
             name: "GCC 13 ASan",
-            build_type: "Debug",
-            cc: "gcc-13",
-            cxx: "g++-13",
-            sanitizer_cmake_flags: "-DWITH_ASAN=ON",
-            aws_cmake_flags: "-DENABLE_ADDRESS_SANITIZER=ON",
-            boost_cmake_flags: "-DCMAKE_CXX_FLAGS_INIT=-fsanitize=address",
-            label: "ASan-gcc13",
+            label: "asan_gcc13",
             run_mtr: true,
             mtr_options: "--sanitize"
           }
         - {
             name: "Clang 17 Debug",
-            build_type: "Debug",
-            cc: "clang-17",
-            cxx: "clang++-17",
-            libcxx_cmake_flags: "-DWITH_STDLIB_LIBCXX=ON",
-            aws_cmake_flags: "-DCMAKE_CXX_FLAGS_INIT=-stdlib=libc++",
-            boost_cmake_flags: "-DCMAKE_CXX_FLAGS_INIT=-stdlib=libc++",
-            label: "Debug-clang17",
+            label: "debug_clang17",
             run_clang_tidy: true
           }
         - {
             name: "Clang 17 RelWithDebInfo",
-            build_type: "RelWithDebInfo",
-            cc: "clang-17",
-            cxx: "clang++-17",
-            libcxx_cmake_flags: "-DWITH_STDLIB_LIBCXX=ON",
-            aws_cmake_flags: "-DCMAKE_CXX_FLAGS_INIT=-stdlib=libc++",
-            boost_cmake_flags: "-DCMAKE_CXX_FLAGS_INIT=-stdlib=libc++",
-            label: "RelWithDebInfo-clang17",
+            label: "release_clang17",
             run_clang_tidy: true
           }
         - {
             name: "Clang 17 ASan",
-            build_type: "Debug",
-            cc: "clang-17",
-            cxx: "clang++-17",
-            libcxx_cmake_flags: "-DWITH_STDLIB_LIBCXX=ON",
-            aws_cmake_flags: "-DCMAKE_CXX_FLAGS_INIT=-stdlib=libc++ -DENABLE_ADDRESS_SANITIZER=ON",
-            boost_cmake_flags: "-DCMAKE_CXX_FLAGS_INIT=\"-stdlib=libc++ -fsanitize=address\"",
-            sanitizer_cmake_flags: "-DWITH_ASAN=ON",
-            label: "ASan-clang17"
+            label: "asan_clang17"
             # TODO: re-enable running MTR under "Clang 17 ASan"
             #   run_mtr: true,
             #   mtr_options: "--sanitize"
@@ -171,20 +140,24 @@ jobs:
         sudo apt-get update
         sudo apt-get install g++-13
 
-    - name: Info CC compiler
-      run: ${{matrix.config.cc}} --version
+    - name: Info CMake
+      run: cmake --version
 
-    - name: Info CXX compiler
-      run: ${{matrix.config.cxx}} --version
+    - name: Info Preset
+      run: echo Current preset ${{matrix.config.label}}
 
-    - name: Creating deps directory
-      run: mkdir -p ${{runner.temp}}/deps
+    - name: Checking out source tree
+      uses: actions/checkout@v4
+      with:
+        path: src
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: Cache boost libraries
       id: cache-boost-static-libraries
       uses: actions/cache@v4
       with:
-        path: ${{runner.temp}}/deps/boost-install-${{matrix.config.label}}
+        path: ${{github.workspace}}/boost-install-${{matrix.config.label}}
         key: ${{format('boost-static-libraries-{0}-{1}-{2}-{3}', env.BOOST_MAJOR, env.BOOST_MINOR, env.BOOST_PATCH, matrix.config.label)}}
 
     - name: Checking out Boost source tree
@@ -197,19 +170,13 @@ jobs:
         submodules: recursive
         fetch-tags: true
 
+    - name: Copying CMake presets for Boost
+      if: steps.cache-boost-static-libraries.outputs.cache-hit != 'true'
+      run: ln -s ${{github.workspace}}/src/extra/cmake_presets/boost/CMakePresets.json ${{github.workspace}}/boost
+
     - name: Configure CMake for Boost
       if: steps.cache-boost-static-libraries.outputs.cache-hit != 'true'
-      run: |
-        cmake \
-          -B ${{github.workspace}}/boost-build-${{matrix.config.label}} \
-          -S ${{github.workspace}}/boost \
-          -DCMAKE_INSTALL_PREFIX=${{runner.temp}}/deps/boost-install-${{matrix.config.label}} \
-          -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}}  \
-          -DCMAKE_C_COMPILER=${{matrix.config.cc}} \
-          -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}} \
-          ${{matrix.config.boost_cmake_flags}} \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DBUILD_TESTING=OFF
+      run: cmake ${{github.workspace}}/boost --preset ${{matrix.config.label}}
 
     - name: CMake info for Boost
       if: steps.cache-boost-static-libraries.outputs.cache-hit != 'true'
@@ -217,17 +184,17 @@ jobs:
 
     - name: Build for Boost
       if: steps.cache-boost-static-libraries.outputs.cache-hit != 'true'
-      run: cmake --build ${{github.workspace}}/boost-build-${{matrix.config.label}} --config ${{matrix.config.build_type}} --parallel
+      run: cmake --build ${{github.workspace}}/boost-build-${{matrix.config.label}} --parallel
 
     - name: Install for Boost
       if: steps.cache-boost-static-libraries.outputs.cache-hit != 'true'
-      run: cmake --install ${{github.workspace}}/boost-build-${{matrix.config.label}} --config ${{matrix.config.build_type}}
+      run: cmake --install ${{github.workspace}}/boost-build-${{matrix.config.label}}
 
     - name: Cache AWS SDK C++ libraries
       id: cache-aws-sdk-cpp-libraries
       uses: actions/cache@v4
       with:
-        path: ${{runner.temp}}/deps/aws-sdk-cpp-install-${{matrix.config.label}}
+        path: ${{github.workspace}}/aws-sdk-cpp-install-${{matrix.config.label}}
         key: ${{format('aws-cpp-sdk-libraries-{0}-{1}-{2}-{3}', env.AWS_SDK_CPP_MAJOR, env.AWS_SDK_CPP_MINOR, env.AWS_SDK_CPP_PATCH, matrix.config.label)}}
 
     - name: Checking out AWS SDK C++ source tree
@@ -240,24 +207,13 @@ jobs:
         submodules: recursive
         fetch-tags: true
 
+    - name: Copying CMake presets for AWS SDK C++
+      if: steps.cache-aws-sdk-cpp-libraries.outputs.cache-hit != 'true'
+      run: ln -s ${{github.workspace}}/src/extra/cmake_presets/aws-sdk-cpp/CMakePresets.json ${{github.workspace}}/aws-sdk-cpp
+
     - name: Configure CMake for AWS SDK C++
       if: steps.cache-aws-sdk-cpp-libraries.outputs.cache-hit != 'true'
-      run: |
-        cmake \
-          -B ${{github.workspace}}/aws-sdk-cpp-build-${{matrix.config.label}} \
-          -S ${{github.workspace}}/aws-sdk-cpp \
-          -DCMAKE_INSTALL_PREFIX=${{runner.temp}}/deps/aws-sdk-cpp-install-${{matrix.config.label}} \
-          -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}}  \
-          -DCMAKE_C_COMPILER=${{matrix.config.cc}} \
-          -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}} \
-          ${{matrix.config.aws_cmake_flags}} \
-          -DCPP_STANDARD=20 \
-          -DENABLE_UNITY_BUILD=ON \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DFORCE_SHARED_CRT=OFF \
-          -DENABLE_TESTING=OFF \
-          -DAUTORUN_UNIT_TESTS=OFF \
-          -DBUILD_ONLY=s3-crt
+      run: cmake ${{github.workspace}}/aws-sdk-cpp --preset ${{matrix.config.label}}
 
     - name: CMake info for AWS SDK C++
       if: steps.cache-aws-sdk-cpp-libraries.outputs.cache-hit != 'true'
@@ -265,42 +221,21 @@ jobs:
 
     - name: Build for AWS SDK C++
       if: steps.cache-aws-sdk-cpp-libraries.outputs.cache-hit != 'true'
-      run: cmake --build ${{github.workspace}}/aws-sdk-cpp-build-${{matrix.config.label}} --config ${{matrix.config.build_type}} --parallel
+      run: cmake --build ${{github.workspace}}/aws-sdk-cpp-build-${{matrix.config.label}} --parallel
 
     - name: Install for AWS SDK C++
       if: steps.cache-aws-sdk-cpp-libraries.outputs.cache-hit != 'true'
-      run: cmake --install ${{github.workspace}}/aws-sdk-cpp-build-${{matrix.config.label}} --config ${{matrix.config.build_type}}
-
-    - name: Checking out source tree
-      uses: actions/checkout@v4
-      with:
-        path: src
-        fetch-depth: 0
-        fetch-tags: true
+      run: cmake --install ${{github.workspace}}/aws-sdk-cpp-build-${{matrix.config.label}}
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: |
-        cmake -Wdev -Werror=dev -Wdeprecated -Werror=deprecated \
-          -B ${{github.workspace}}/build-${{matrix.config.label}} \
-          -S ${{github.workspace}}/src \
-          -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}}  \
-          -DCMAKE_C_COMPILER=${{matrix.config.cc}} \
-          -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}} \
-          -DCPP_STANDARD=20 \
-          ${{matrix.config.libcxx_cmake_flags}} \
-          ${{matrix.config.sanitizer_cmake_flags}} \
-          -DCMAKE_PREFIX_PATH=${{runner.temp}}/deps/aws-sdk-cpp-install-${{matrix.config.label}} \
-          -DBoost_ROOT=${{runner.temp}}/deps/boost-install-${{matrix.config.label}} \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      run: cmake ${{github.workspace}}/src --preset ${{matrix.config.label}}
 
     - name: CMake info
-      run: cmake -L ${{github.workspace}}/build-${{matrix.config.label}}
+      run: cmake -L ${{github.workspace}}/src-build-${{matrix.config.label}}
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build-${{matrix.config.label}} --config ${{matrix.config.build_type}} --parallel
+      run: cmake --build ${{github.workspace}}/src-build-${{matrix.config.label}} --parallel
 
     - name: Info Clang Tidy
       if: matrix.config.run_clang_tidy
@@ -309,7 +244,7 @@ jobs:
     - name: Clang Tidy
       if: matrix.config.run_clang_tidy
       # Run Clang Tidy
-      run: run-clang-tidy-17 -header-filter=.* -j=${{steps.cpu-cores.outputs.count}} -use-color -p=${{github.workspace}}/build-${{matrix.config.label}}
+      run: run-clang-tidy-17 -header-filter=.* -j=${{steps.cpu-cores.outputs.count}} -use-color -p=${{github.workspace}}/src-build-${{matrix.config.label}}
 
     - name: MTR tests
       if: matrix.config.run_mtr
@@ -320,19 +255,18 @@ jobs:
         # Linking the "binlog_streaming" from the source tree into the MTR suits directory on the system
         sudo ln -s ${{github.workspace}}/src/mtr/binlog_streaming /usr/lib/mysql-test/suite/binlog_streaming
         # Running MTR from the system package
-        BINSRV=${{github.workspace}}/build-${{matrix.config.label}}/binlog_server ./mtr \
+        BINSRV=${{github.workspace}}/src-build-${{matrix.config.label}}/binlog_server ./mtr \
           --client-bindir=/usr/lib/mysql-test/bin --vardir=${{runner.temp}}/mtrvardir \
           --force --max-test-fail=0 --retry=0 --nounit-tests --big-test --repeat=2 --parallel=${{steps.cpu-cores.outputs.count}} \
           --suite=binlog_streaming ${{matrix.config.mtr_options}}
 
     - name: CTest
-      working-directory: ${{github.workspace}}/build-${{matrix.config.label}}
+      working-directory: ${{github.workspace}}/src-build-${{matrix.config.label}}
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{matrix.config.build_type}} --parallel
+      run: ctest --parallel
 
     - name: Info Build artefacts
       run: |
         ls -la ${{github.workspace}}
         ls -la ${{runner.temp}}
-        ls -la ${{runner.temp}}/deps

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,119 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "common_hidden",
+      "hidden": true,
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceParentDir}/${sourceDirName}-build-${presetName}",
+      "installDir": "${sourceParentDir}/${sourceDirName}-install-${presetName}",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "${sourceParentDir}/aws-sdk-cpp-install-${presetName};${sourceParentDir}/boost-install-${presetName}",
+        "CPP_STANDARD": "20",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+
+    {
+      "name": "debug_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "asan_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "WITH_ASAN": "ON"
+      }
+    },
+
+    {
+      "name": "gcc13_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc-13",
+        "CMAKE_CXX_COMPILER": "g++-13"
+      }
+    },
+    {
+      "name": "clang17_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-17",
+        "CMAKE_CXX_COMPILER": "clang++-17",
+        "WITH_STDLIB_LIBCXX": "ON"
+      }
+    },
+
+    {
+      "name": "debug_gcc13",
+      "inherits": [
+        "common_hidden",
+        "debug_hidden",
+        "gcc13_hidden"
+      ],
+      "displayName": "GCC 13 Debug"
+    },
+    {
+      "name": "release_gcc13",
+      "inherits": [
+        "common_hidden",
+        "release_hidden",
+        "gcc13_hidden"
+      ],
+      "displayName": "GCC 13 RelWithDebInfo"
+    },
+    {
+      "name": "asan_gcc13",
+      "inherits": [
+        "common_hidden",
+        "asan_hidden",
+        "gcc13_hidden"
+      ],
+      "displayName": "GCC 13 ASan"
+    },
+
+    {
+      "name": "debug_clang17",
+      "inherits": [
+        "common_hidden",
+        "debug_hidden",
+        "clang17_hidden"
+      ],
+      "displayName": "Clang 17 Debug"
+    },
+    {
+      "name": "release_clang17",
+      "inherits": [
+        "common_hidden",
+        "release_hidden",
+        "clang17_hidden"
+      ],
+      "displayName": "Clang 17 RelWithDebInfo"
+    },
+    {
+      "name": "asan_clang17",
+      "inherits": [
+        "common_hidden",
+        "asan_hidden",
+        "clang17_hidden"
+      ],
+      "displayName": "Clang 17 ASan"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -32,58 +32,45 @@ Every next step will assume that we are currently inside the `ws` directory unle
 
 ##### Defining environment variables affecting build configurations
 
-Define `BUILD_CONFIGURATION` depending on whether you want to build `Debug` or `Release` version of the library.
+Define `BUILD_PRESET` depending on whether you want to build in `Debug`, `Release`, or `Debug` with `Address Sanitizer` configuration and which toolset you would like to use.
 
 ```bash
-export BUILD_CONFIGURATION=Debug
+export BUILD_PRESET=<configuration>_<toolset>
 ```
-or
+The supported values for `<configuration>` are `debug`, `release`, and `asan`.
+The supported values for `<toolset>` are `gcc13` and  `clang17`.
+
+For instance, if you want to build in `RelWithDebInfo` configuration using `GCC 13`, please specify
 ```bash
-export BUILD_CONFIGURATION=RelWithDebInfo
+export BUILD_PRESET=release_gcc13
 ```
-Define `BUILD_CC` and `BUILD_CXX` depending on the compiler you wish to use.
-```bash
-export BUILD_CC=gcc
-export BUILD_CXX=g++
-```
-Instead of `gcc` you may use `gcc-12` / `gcc-13` / `gcc-14` or `clang-15` / `clang-16` / `clang-17`.
-Instead of `g++` you may use `g++-12` / `g++-13` / `g++-14` or `clang++-15` / `clang++-16` / `clang++-17`.
-Make sure that versions of the `CC` and `CXX` compilers match.
 
 ##### Boost Libraries
 
 ###### Getting Boost Libraries source
 
 ```bash
-git clone --recurse-submodules --jobs=8 https://github.com/boostorg/boost.git
+git clone --recurse-submodules -b boost-1.84.0 --jobs=8 https://github.com/boostorg/boost.git
 cd boost
-git checkout --recurse-submodules -b required_release boost-1.84.0
+git switch -c required_release
 ```
 
 ###### Configuring Boost Libraries
 
 ```bash
-cmake \
-  -B ./boost-build-${BUILD_CONFIGURATION} \
-  -S ./boost \
-  -DCMAKE_INSTALL_PREFIX=./boost-install-${BUILD_CONFIGURATION} \
-  -DCMAKE_BUILD_TYPE=${BUILD_CONFIGURATION} \
-  -DCMAKE_C_COMPILER=${BUILD_CC} \
-  -DCMAKE_CXX_COMPILER=${BUILD_CXX} \
-  -DBUILD_SHARED_LIBS=OFF \
-  -DBUILD_TESTING=OFF
+cmake ./boost --preset ${BUILD_PRESET}
 ```
 
 ###### Building Boost Libraries
 
 ```bash
-cmake --build ./boost-build-${BUILD_CONFIGURATION} --config ${BUILD_CONFIGURATION} --parallel
+cmake --build ./boost-build-${BUILD_PRESET} --parallel
 ```
 
 ###### Installing Boost Libraries
 
 ```bash
-cmake --install ./boost-build-${BUILD_CONFIGURATION} --config ${BUILD_CONFIGURATION}
+cmake --install ./boost-build-${BUILD_PRESET}
 ```
 
 ##### AWS SDK CPP Libraries
@@ -93,38 +80,25 @@ cmake --install ./boost-build-${BUILD_CONFIGURATION} --config ${BUILD_CONFIGURAT
 ```bash
 git clone --recurse-submodules --jobs=8 https://github.com/aws/aws-sdk-cpp
 cd aws-sdk-cpp
-git checkout --recurse-submodules -b required_release 1.11.286
+git switch -c required_release
 ```
 
 ###### Configuring AWS SDK CPP Libraries
 
 ```bash
-cmake \
-  -B ./aws-sdk-cpp-build-${BUILD_CONFIGURATION} \
-  -S ./aws-sdk-cpp \
-  -DCMAKE_INSTALL_PREFIX=./aws-sdk-cpp-install-${BUILD_CONFIGURATION} \
-  -DCMAKE_BUILD_TYPE=${BUILD_CONFIGURATION} \
-  -DCMAKE_C_COMPILER=${BUILD_CC} \
-  -DCMAKE_CXX_COMPILER=${BUILD_CXX} \
-  -DCPP_STANDARD=20 \
-  -DENABLE_UNITY_BUILD=ON \
-  -DBUILD_SHARED_LIBS=OFF \
-  -DFORCE_SHARED_CRT=OFF \
-  -DENABLE_TESTING=OFF \
-  -DAUTORUN_UNIT_TESTS=OFF \
-  -DBUILD_ONLY=s3-crt
+cmake ./aws-sdk-cpp --preset ${BUILD_PRESET}
 ```
 
 ###### Building AWS SDK CPP Libraries
 
 ```bash
-cmake --build ./aws-sdk-cpp-build-${BUILD_CONFIGURATION} --config ${BUILD_CONFIGURATION} --parallel
+cmake --build ./aws-sdk-cpp-build-${BUILD_PRESET} --parallel
 ```
 
 ###### Installing AWS SDK CPP Libraries
 
 ```bash
-cmake --install ./aws-sdk-cpp-build-${BUILD_CONFIGURATION} --config ${BUILD_CONFIGURATION}
+cmake --install ./aws-sdk-cpp-build-${BUILD_PRESET}
 ```
 ##### Main Application
 
@@ -137,26 +111,18 @@ git clone https://github.com/Percona-Lab/percona-binlog-server.git
 ###### Configuring Main Application
 
 ```bash
-cmake  \
-  -B ./percona-binlog-server-build-${BUILD_CONFIGURATION} \
-  -S ./percona-binlog-server \
-  -DCMAKE_BUILD_TYPE=${BUILD_CONFIGURATION} \
-  -DCMAKE_C_COMPILER=${BUILD_CC} \
-  -DCMAKE_CXX_COMPILER=${BUILD_CXX} \
-  -DCPP_STANDARD=20 \
-  -DCMAKE_PREFIX_PATH=${PWD}/aws-sdk-cpp-install-${BUILD_CONFIGURATION} \
-  -DBoost_ROOT=${PWD}/boost-install-${BUILD_CONFIGURATION}
+cmake ./percona-binlog-server --preset ${BUILD_PRESET}
 ```
 
 ###### Building Main Application
 
 ```bash
-cmake --build ./percona-binlog-server-build-${BUILD_CONFIGURATION} --config ${BUILD_CONFIGURATION} --parallel
+cmake --build ./percona-binlog-server-build-${BUILD_PRESET} --parallel
 ```
 
 ###### Main Application binary
 
-The result binary can be found under the following path `ws/percona-binlog-server-build-${BUILD_CONFIGURATION}/binlog_server`
+The result binary can be found under the following path `ws/percona-binlog-server-build-${BUILD_PRESET}/binlog_server`
 
 ## Usage
 

--- a/extra/cmake_presets/aws-sdk-cpp/CMakePresets.json
+++ b/extra/cmake_presets/aws-sdk-cpp/CMakePresets.json
@@ -1,0 +1,123 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "common_hidden",
+      "hidden": true,
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceParentDir}/${sourceDirName}-build-${presetName}",
+      "installDir": "${sourceParentDir}/${sourceDirName}-install-${presetName}",
+      "cacheVariables": {
+        "CPP_STANDARD": "20",
+        "ENABLE_UNITY_BUILD": "ON",
+        "BUILD_SHARED_LIBS": "OFF",
+        "FORCE_SHARED_CRT": "OFF",
+        "ENABLE_TESTING": "OFF",
+        "AUTORUN_UNIT_TESTS": "OFF",
+        "BUILD_ONLY": "s3-crt"
+      }
+    },
+
+    {
+      "name": "debug_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "asan_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_ADDRESS_SANITIZER": "ON"
+      }
+    },
+
+    {
+      "name": "gcc13_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc-13",
+        "CMAKE_CXX_COMPILER": "g++-13"
+      }
+    },
+    {
+      "name": "clang17_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-17",
+        "CMAKE_CXX_COMPILER": "clang++-17",
+        "CMAKE_CXX_FLAGS_INIT": "-stdlib=libc++"
+      }
+    },
+
+    {
+      "name": "debug_gcc13",
+      "inherits": [
+        "common_hidden",
+        "debug_hidden",
+        "gcc13_hidden"
+      ],
+      "displayName": "GCC 13 Debug"
+    },
+    {
+      "name": "release_gcc13",
+      "inherits": [
+        "common_hidden",
+        "release_hidden",
+        "gcc13_hidden"
+      ],
+      "displayName": "GCC 13 RelWithDebInfo"
+    },
+    {
+      "name": "asan_gcc13",
+      "inherits": [
+        "common_hidden",
+        "asan_hidden",
+        "gcc13_hidden"
+      ],
+      "displayName": "GCC 13 ASan"
+    },
+
+    {
+      "name": "debug_clang17",
+      "inherits": [
+        "common_hidden",
+        "debug_hidden",
+        "clang17_hidden"
+      ],
+      "displayName": "Clang 17 Debug"
+    },
+    {
+      "name": "release_clang17",
+      "inherits": [
+        "common_hidden",
+        "release_hidden",
+        "clang17_hidden"
+      ],
+      "displayName": "Clang 17 RelWithDebInfo"
+    },
+    {
+      "name": "asan_clang17",
+      "inherits": [
+        "common_hidden",
+        "asan_hidden",
+        "clang17_hidden"
+      ],
+      "displayName": "Clang 17 ASan"
+    }
+  ]
+}

--- a/extra/cmake_presets/boost/CMakePresets.json
+++ b/extra/cmake_presets/boost/CMakePresets.json
@@ -1,0 +1,123 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "common_hidden",
+      "hidden": true,
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceParentDir}/${sourceDirName}-build-${presetName}",
+      "installDir": "${sourceParentDir}/${sourceDirName}-install-${presetName}",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS_INIT": "$env{ASAN_FLAGS} $env{STDLIB_FLAGS}",
+        "BUILD_SHARED_LIBS": "OFF",
+        "BUILD_TESTING": "OFF"
+      }
+    },
+
+    {
+      "name": "debug_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "asan_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "environment": {
+        "ASAN_FLAGS": "-fsanitize=address"
+      }
+    },
+
+    {
+      "name": "gcc13_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc-13",
+        "CMAKE_CXX_COMPILER": "g++-13"
+      }
+    },
+    {
+      "name": "clang17_hidden",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-17",
+        "CMAKE_CXX_COMPILER": "clang++-17"
+      },
+      "environment": {
+        "STDLIB_FLAGS": "-stdlib=libc++"
+      }
+    },
+
+    {
+      "name": "debug_gcc13",
+      "inherits": [
+        "common_hidden",
+        "debug_hidden",
+        "gcc13_hidden"
+      ],
+      "displayName": "GCC 13 Debug"
+    },
+    {
+      "name": "release_gcc13",
+      "inherits": [
+        "common_hidden",
+        "release_hidden",
+        "gcc13_hidden"
+      ],
+      "displayName": "GCC 13 RelWithDebInfo"
+    },
+    {
+      "name": "asan_gcc13",
+      "inherits": [
+        "common_hidden",
+        "asan_hidden",
+        "gcc13_hidden"
+      ],
+      "displayName": "GCC 13 ASan"
+    },
+
+    {
+      "name": "debug_clang17",
+      "inherits": [
+        "common_hidden",
+        "debug_hidden",
+        "clang17_hidden"
+      ],
+      "displayName": "Clang 17 Debug"
+    },
+    {
+      "name": "release_clang17",
+      "inherits": [
+        "common_hidden",
+        "release_hidden",
+        "clang17_hidden"
+      ],
+      "displayName": "Clang 17 RelWithDebInfo"
+    },
+    {
+      "name": "asan_clang17",
+      "inherits": [
+        "common_hidden",
+        "asan_hidden",
+        "clang17_hidden"
+      ],
+      "displayName": "Clang 17 ASan"
+    }
+  ]
+}


### PR DESCRIPTION
All 3 projects now have the following CMake presets
* 'debug_gcc13' - Debug configuration for GCC 13 toolset
* 'release_gcc13' - RelWithDebInfo configuration for GCC 13 toolset
* 'asan_gcc13' - Debug configuration with Address Sanitizer enabled for GCC 13 toolset
* 'debug_clang17' - Debug configuration for Clang 17 toolset
* 'release_clang17' - RelWithDebInfo configuration for Clang 17 toolset
* 'asan_clang17' - Debug configuration with Address Sanitizer enabled for Clang 17 toolset

For each project ('boost', 'aws-sdk-cpp' and 'percona-binlog-server') you can now enter its source directory
cd <project_name>
and run
cmake . --preset <preset_name>
and a new directory
<project_name>-build-<preset_name> will appear alongside <project_name> After that, in order to build, you can run
cmake --build <project_name>-build-<preset_name> --parallel And finally, to install it you can run
cmake --install <project_name>-build-<preset_name>

CMakePresets.json for the main project is put into the root of the source tree, alongside CMakeLists.txt. For Boost and AWS SDK C++ the files are put into the 'extra/cmake_presets' directory under corresponding subdirectories. Before starting configuring Boost / AWS SDK C++ these files need to be copied / symlinked into the roots of those project source trees.

Significantly reworked GitHub Actions .yml file.
* In order to keep build options in one place, GitHub Actions now also use CMake presets.
* Fetching main project's source code is now performed before building dependency libraries. It is necessary because we need to have access to the dependency libraries CMakePresets.json files earlier.
* Added "Info CMake" action that prints CMake version

Changed the way how we instruct main application to look for Boost libraries during the configuration stage. Instead of specifying 'Boost_ROOT', we now use 'CMAKE_PREFIX_PATH' to specify a path where CMake can find 'BoostConfig.cmake'. This helps to avoid some CMake warnings generated in newer (>=3.30.0) versions of cmake.

Updated build instructions in README.md to reflect CMake presets changes.