### PR TITLE
Updated clang toolset to version 18

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 Checks: "
   *,
-  -altera-*
+  -altera-*,
   -fuchsia-*,
   -android-*,
   -google-*,

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   formatting-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Formatting checks
     steps:
       - name: Cheking out source tree
@@ -37,24 +37,22 @@ jobs:
 
       - name: Install dependencies on ubuntu
         run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          echo deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update
-          sudo apt-get install clang-format-17
+          sudo apt-get install clang-format-18
 
       - name: Info Clang Format
-        run: clang-format-17 --version
+        run: clang-format-18 --version
 
-      - name: Check formatting with git clang-format-17
+      - name: Check formatting with git clang-format-18
         working-directory: ${{github.workspace}}/src
-        run: git clang-format-17 --diff --binary=clang-format-17 HEAD~
+        run: git clang-format-18 --diff --binary=clang-format-18 HEAD~
 
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     name: ${{ matrix.config.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -76,24 +74,24 @@ jobs:
             mtr_options: "--sanitize"
           }
         - {
-            name: "Clang 17 Debug",
-            label: "debug_clang17",
+            name: "Clang 18 Debug",
+            label: "debug_clang18",
             run_clang_tidy: true
           }
         - {
-            name: "Clang 17 RelWithDebInfo",
-            label: "release_clang17",
+            name: "Clang 18 RelWithDebInfo",
+            label: "release_clang18",
             run_clang_tidy: true
           }
         - {
-            name: "Clang 17 ASan",
-            label: "asan_clang17"
-            # TODO: re-enable running MTR under "Clang 17 ASan"
+            name: "Clang 18 ASan",
+            label: "asan_clang18"
+            # TODO: re-enable running MTR under "Clang 18 ASan"
             #   run_mtr: true,
             #   mtr_options: "--sanitize"
             # when "-stdlib=libc++ -fsanitize=address" alloc-dealloc-mismatch issue is fixed
             # (https://github.com/llvm/llvm-project/issues/59432)
-            # or CI is upgraded to Clang 18
+            # or CI is upgraded to Clang 19
           }
 
     steps:
@@ -128,15 +126,12 @@ jobs:
     - name: Install Clang dependencies on ubuntu
       if: startsWith(matrix.config.name, 'Clang')
       run: |
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-        echo deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main | sudo tee /etc/apt/sources.list.d/llvm.list
         sudo apt-get update
-        sudo apt-get install clang-17 lld-17 clang-tidy-17 libc++-17-dev libc++1-17 libc++abi-17-dev libc++abi1-17
+        sudo apt-get install clang-18 lld-18 clang-tidy-18 libc++-18-dev libc++1-18 libc++abi-18-dev libc++abi1-18
 
     - name: Install GCC dependencies on ubuntu
       if: startsWith(matrix.config.name, 'GCC')
       run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get update
         sudo apt-get install g++-13
 
@@ -239,19 +234,23 @@ jobs:
 
     - name: Info Clang Tidy
       if: matrix.config.run_clang_tidy
-      run: clang-tidy-17 --version
+      run: clang-tidy-18 --version
 
     - name: Clang Tidy
       if: matrix.config.run_clang_tidy
       # Run Clang Tidy
-      run: run-clang-tidy-17 -header-filter=.* -j=${{steps.cpu-cores.outputs.count}} -use-color -p=${{github.workspace}}/src-build-${{matrix.config.label}}
+      run: run-clang-tidy-18 -header-filter=.* -j=${{steps.cpu-cores.outputs.count}} -use-color -p=${{github.workspace}}/src-build-${{matrix.config.label}}
 
     - name: MTR tests
       if: matrix.config.run_mtr
       working-directory: /usr/lib/mysql-test
       run: |
-        # Switching MySQL Server Apparmor profile to "complain" as we are creating a custom data directory
-        sudo aa-complain /usr/sbin/mysqld
+        # TODO: consider adding ${{runner.temp}}/mtrvardir into the list of
+        # writable directories in '/etc/apparmor.d/usr.sbin.mysqld' AppArmor
+        # profile instead of disabling it completely.
+        # Disabling MySQL Server Apparmor profile as we are creating a custom data directory
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         # Linking the "binlog_streaming" from the source tree into the MTR suits directory on the system
         sudo ln -s ${{github.workspace}}/src/mtr/binlog_streaming /usr/lib/mysql-test/suite/binlog_streaming
         # Running MTR from the system package

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,11 +51,11 @@
       }
     },
     {
-      "name": "clang17_hidden",
+      "name": "clang18_hidden",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-17",
-        "CMAKE_CXX_COMPILER": "clang++-17",
+        "CMAKE_C_COMPILER": "clang-18",
+        "CMAKE_CXX_COMPILER": "clang++-18",
         "WITH_STDLIB_LIBCXX": "ON"
       }
     },
@@ -89,31 +89,31 @@
     },
 
     {
-      "name": "debug_clang17",
+      "name": "debug_clang18",
       "inherits": [
         "common_hidden",
         "debug_hidden",
-        "clang17_hidden"
+        "clang18_hidden"
       ],
-      "displayName": "Clang 17 Debug"
+      "displayName": "Clang 18 Debug"
     },
     {
-      "name": "release_clang17",
+      "name": "release_clang18",
       "inherits": [
         "common_hidden",
         "release_hidden",
-        "clang17_hidden"
+        "clang18_hidden"
       ],
-      "displayName": "Clang 17 RelWithDebInfo"
+      "displayName": "Clang 18 RelWithDebInfo"
     },
     {
-      "name": "asan_clang17",
+      "name": "asan_clang18",
       "inherits": [
         "common_hidden",
         "asan_hidden",
-        "clang17_hidden"
+        "clang18_hidden"
       ],
-      "displayName": "Clang 17 ASan"
+      "displayName": "Clang 18 ASan"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently prebuilt binaries are not available.
 #### Dependencies
 
 - [CMake](https://cmake.org/) 3.20.0+
-- [Clang](https://clang.llvm.org/) (`clang-15` / `clang-16` / `clang-17`) or [GCC](https://gcc.gnu.org/) (`gcc-12` / `gcc-13` / `gcc-14`)
+- [Clang](https://clang.llvm.org/) (`clang-15` .. `clang-18`) or [GCC](https://gcc.gnu.org/) (`gcc-12` .. `gcc-14`)
 - [Boost libraries](https://www.boost.org/) 1.88.0 (git version, not the source tarball)
 - [MySQL client library](https://dev.mysql.com/doc/c-api/8.0/en/) 8.0.x (`libmysqlclient`)
 - [CURL library](https://curl.se/libcurl/) (`libcurl`) 8.6.0+
@@ -44,7 +44,7 @@ Define `BUILD_PRESET` depending on whether you want to build in `Debug`, `Releas
 export BUILD_PRESET=<configuration>_<toolset>
 ```
 The supported values for `<configuration>` are `debug`, `release`, and `asan`.
-The supported values for `<toolset>` are `gcc13` and  `clang17`.
+The supported values for `<toolset>` are `gcc13` and  `clang18`.
 
 For instance, if you want to build in `RelWithDebInfo` configuration using `GCC 13`, please specify
 ```bash

--- a/extra/cmake_presets/aws-sdk-cpp/CMakePresets.json
+++ b/extra/cmake_presets/aws-sdk-cpp/CMakePresets.json
@@ -55,11 +55,11 @@
       }
     },
     {
-      "name": "clang17_hidden",
+      "name": "clang18_hidden",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-17",
-        "CMAKE_CXX_COMPILER": "clang++-17",
+        "CMAKE_C_COMPILER": "clang-18",
+        "CMAKE_CXX_COMPILER": "clang++-18",
         "CMAKE_CXX_FLAGS_INIT": "-stdlib=libc++"
       }
     },
@@ -93,31 +93,31 @@
     },
 
     {
-      "name": "debug_clang17",
+      "name": "debug_clang18",
       "inherits": [
         "common_hidden",
         "debug_hidden",
-        "clang17_hidden"
+        "clang18_hidden"
       ],
-      "displayName": "Clang 17 Debug"
+      "displayName": "Clang 18 Debug"
     },
     {
-      "name": "release_clang17",
+      "name": "release_clang18",
       "inherits": [
         "common_hidden",
         "release_hidden",
-        "clang17_hidden"
+        "clang18_hidden"
       ],
-      "displayName": "Clang 17 RelWithDebInfo"
+      "displayName": "Clang 18 RelWithDebInfo"
     },
     {
-      "name": "asan_clang17",
+      "name": "asan_clang18",
       "inherits": [
         "common_hidden",
         "asan_hidden",
-        "clang17_hidden"
+        "clang18_hidden"
       ],
-      "displayName": "Clang 17 ASan"
+      "displayName": "Clang 18 ASan"
     }
   ]
 }

--- a/extra/cmake_presets/boost/CMakePresets.json
+++ b/extra/cmake_presets/boost/CMakePresets.json
@@ -53,11 +53,11 @@
       }
     },
     {
-      "name": "clang17_hidden",
+      "name": "clang18_hidden",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-17",
-        "CMAKE_CXX_COMPILER": "clang++-17"
+        "CMAKE_C_COMPILER": "clang-18",
+        "CMAKE_CXX_COMPILER": "clang++-18"
       },
       "environment": {
         "STDLIB_FLAGS": "-stdlib=libc++"
@@ -93,31 +93,31 @@
     },
 
     {
-      "name": "debug_clang17",
+      "name": "debug_clang18",
       "inherits": [
         "common_hidden",
         "debug_hidden",
-        "clang17_hidden"
+        "clang18_hidden"
       ],
-      "displayName": "Clang 17 Debug"
+      "displayName": "Clang 18 Debug"
     },
     {
-      "name": "release_clang17",
+      "name": "release_clang18",
       "inherits": [
         "common_hidden",
         "release_hidden",
-        "clang17_hidden"
+        "clang18_hidden"
       ],
-      "displayName": "Clang 17 RelWithDebInfo"
+      "displayName": "Clang 18 RelWithDebInfo"
     },
     {
-      "name": "asan_clang17",
+      "name": "asan_clang18",
       "inherits": [
         "common_hidden",
         "asan_hidden",
-        "clang17_hidden"
+        "clang18_hidden"
       ],
-      "displayName": "Clang 17 ASan"
+      "displayName": "Clang 18 ASan"
     }
   ]
 }

--- a/src/binsrv/basic_storage_backend.cpp
+++ b/src/binsrv/basic_storage_backend.cpp
@@ -36,7 +36,7 @@ basic_storage_backend::get_object(std::string_view name) {
 
 void basic_storage_backend::put_object(std::string_view name,
                                        util::const_byte_span content) {
-  return do_put_object(name, content);
+  do_put_object(name, content);
 }
 
 void basic_storage_backend::open_stream(std::string_view name,

--- a/src/binsrv/basic_storage_backend_fwd.hpp
+++ b/src/binsrv/basic_storage_backend_fwd.hpp
@@ -23,7 +23,7 @@
 
 namespace binsrv {
 
-enum class storage_backend_open_stream_mode { create, append };
+enum class storage_backend_open_stream_mode : std::uint8_t { create, append };
 
 class basic_storage_backend;
 

--- a/src/binsrv/event/reader_context.hpp
+++ b/src/binsrv/event/reader_context.hpp
@@ -18,6 +18,8 @@
 
 #include "binsrv/event/reader_context_fwd.hpp" // IWYU pragma: export
 
+#include <cstdint>
+
 #include "binsrv/event/checksum_algorithm_type_fwd.hpp"
 #include "binsrv/event/common_header_fwd.hpp"
 #include "binsrv/event/event_fwd.hpp"
@@ -42,7 +44,7 @@ public:
 private:
   // this class implements the logic of the following state machine
   // (ROTATE(artificial) FORMAT_DESCRIPTION <ANY>* (ROTATE|STOP)?)+
-  enum class state_type {
+  enum class state_type : std::uint8_t {
     initial,
     rotate_artificial_processed,
     format_description_processed

--- a/src/binsrv/filesystem_storage_backend.cpp
+++ b/src/binsrv/filesystem_storage_backend.cpp
@@ -28,10 +28,6 @@
 #include <boost/url/scheme.hpp>
 #include <boost/url/url_view_base.hpp>
 
-// TODO: remove this include when switching to clang-18 where transitive
-//       IWYU 'export' pragmas are handled properly
-#include "binsrv/basic_storage_backend_fwd.hpp"
-
 #include "util/byte_span.hpp"
 #include "util/exception_location_helpers.hpp"
 

--- a/src/binsrv/s3_storage_backend.cpp
+++ b/src/binsrv/s3_storage_backend.cpp
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -54,9 +55,6 @@
 #include <aws/s3-crt/model/ListObjectsV2Result.h>
 #include <aws/s3-crt/model/PutObjectRequest.h>
 
-// TODO: remove this include when switching to clang-18 where transitive
-//       IWYU 'export' pragmas are handled properly
-#include "binsrv/basic_storage_backend_fwd.hpp"
 #include "binsrv/s3_error_helpers_private.hpp"
 
 #include "util/byte_span.hpp"
@@ -97,7 +95,7 @@ struct qualified_object_path {
 
 class s3_storage_backend::aws_context : private aws_context_base {
 public:
-  enum class construction_alternative { bucket, region };
+  enum class construction_alternative : std::uint8_t { bucket, region };
   using stream_factory_type = std::function<std::iostream *()>;
   using stream_handler_type = std::function<void(std::size_t, std::iostream &)>;
 

--- a/src/easymysql/connection_fwd.hpp
+++ b/src/easymysql/connection_fwd.hpp
@@ -16,9 +16,14 @@
 #ifndef EASYMYSQL_CONNECTION_FWD_HPP
 #define EASYMYSQL_CONNECTION_FWD_HPP
 
+#include <cstdint>
+
 namespace easymysql {
 
-enum class connection_replication_mode_type { blocking, non_blocking };
+enum class connection_replication_mode_type : std::uint8_t {
+  blocking,
+  non_blocking
+};
 
 class connection;
 

--- a/src/util/ct_string.hpp
+++ b/src/util/ct_string.hpp
@@ -47,13 +47,13 @@ template <std::size_t N> struct ct_string {
 };
 
 template <std::size_t N1, std::size_t N2>
-constexpr inline auto operator==(const ct_string<N1> &cts1,
-                                 const ct_string<N2> &cts2) noexcept {
+constexpr auto operator==(const ct_string<N1> &cts1,
+                          const ct_string<N2> &cts2) noexcept {
   return cts1.sv() == cts2.sv();
 }
 template <std::size_t N1, std::size_t N2>
-constexpr inline auto operator<=>(const ct_string<N1> &cts1,
-                                  const ct_string<N2> &cts2) noexcept {
+constexpr auto operator<=>(const ct_string<N1> &cts1,
+                           const ct_string<N2> &cts2) noexcept {
   return cts1.sv() <=> cts2.sv();
 }
 


### PR DESCRIPTION

GitHub Actions workers now use 'ubuntu-24.04' image that have more
recent toolsets as a part of standard distribution.
'apt.llvm.org' package repository is no longer used for 'clang'.
'ppa:ubuntu-toolchain-r/test' package repository is no longer used for
'gcc'.

CMake presets for Boost, AWS SDK C++ and the main projects now use
'clang-18'.

GitHub Actions scripts now use 'clang18_xxx' presets instead of
'clang17_xxx'.

Clang Format and Clang Tidy invocations in GitHub Actions scripts
changed to version 18.

Fixed problem with missing comma in the 'Checks' section of the
'.clang-tidy' settings file which caused enabling 'fuchsia-*' checks
after switching to clang-18.

Fixed new clang-18-specific Clang Tidy warnings in the source code.

Verified that "-stdlib=libc++ -fsanitize=address" alloc-dealloc-mismatch
issue (https://github.com/llvm/llvm-project/issues/59432) still exists
in Clang 18 - updated TODO item to try again in Clang 19.

Before running MTR we now completely disable MySQL Server AppArmor
profile in the GitHub Actions script.