### PR TITLE
Updated clang toolset to version 19

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,14 +38,14 @@ jobs:
       - name: Install dependencies on ubuntu
         run: |
           sudo apt-get update
-          sudo apt-get install clang-format-18
+          sudo apt-get install clang-format-19
 
       - name: Info Clang Format
-        run: clang-format-18 --version
+        run: clang-format-19 --version
 
-      - name: Check formatting with git clang-format-18
+      - name: Check formatting with git clang-format-19
         working-directory: ${{github.workspace}}/src
-        run: git clang-format-18 --diff --binary=clang-format-18 HEAD~
+        run: git clang-format-19 --diff --binary=clang-format-19 HEAD~
 
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
@@ -74,24 +74,24 @@ jobs:
             mtr_options: "--sanitize"
           }
         - {
-            name: "Clang 18 Debug",
-            label: "debug_clang18",
+            name: "Clang 19 Debug",
+            label: "debug_clang19",
             run_clang_tidy: true
           }
         - {
-            name: "Clang 18 RelWithDebInfo",
-            label: "release_clang18",
+            name: "Clang 19 RelWithDebInfo",
+            label: "release_clang19",
             run_clang_tidy: true
           }
         - {
-            name: "Clang 18 ASan",
-            label: "asan_clang18"
-            # TODO: re-enable running MTR under "Clang 18 ASan"
+            name: "Clang 19 ASan",
+            label: "asan_clang19"
+            # TODO: re-enable running MTR under this "Clang XX ASan"
             #   run_mtr: true,
             #   mtr_options: "--sanitize"
             # when "-stdlib=libc++ -fsanitize=address" alloc-dealloc-mismatch issue is fixed
             # (https://github.com/llvm/llvm-project/issues/59432)
-            # or CI is upgraded to Clang 19
+            # or CI is upgraded to Clang 20
           }
 
     steps:
@@ -127,7 +127,7 @@ jobs:
       if: startsWith(matrix.config.name, 'Clang')
       run: |
         sudo apt-get update
-        sudo apt-get install clang-18 lld-18 clang-tidy-18 libc++-18-dev libc++1-18 libc++abi-18-dev libc++abi1-18
+        sudo apt-get install clang-19 lld-19 clang-tidy-19 libc++-19-dev libc++abi-19-dev
 
     - name: Install GCC dependencies on ubuntu
       if: startsWith(matrix.config.name, 'GCC')
@@ -234,12 +234,12 @@ jobs:
 
     - name: Info Clang Tidy
       if: matrix.config.run_clang_tidy
-      run: clang-tidy-18 --version
+      run: clang-tidy-19 --version
 
     - name: Clang Tidy
       if: matrix.config.run_clang_tidy
       # Run Clang Tidy
-      run: run-clang-tidy-18 -header-filter=.* -j=${{steps.cpu-cores.outputs.count}} -use-color -p=${{github.workspace}}/src-build-${{matrix.config.label}}
+      run: run-clang-tidy-19 -header-filter=.* -j=${{steps.cpu-cores.outputs.count}} -use-color -p=${{github.workspace}}/src-build-${{matrix.config.label}}
 
     - name: MTR tests
       if: matrix.config.run_mtr

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,11 +51,11 @@
       }
     },
     {
-      "name": "clang18_hidden",
+      "name": "clang19_hidden",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-18",
-        "CMAKE_CXX_COMPILER": "clang++-18",
+        "CMAKE_C_COMPILER": "clang-19",
+        "CMAKE_CXX_COMPILER": "clang++-19",
         "WITH_STDLIB_LIBCXX": "ON"
       }
     },
@@ -89,31 +89,31 @@
     },
 
     {
-      "name": "debug_clang18",
+      "name": "debug_clang19",
       "inherits": [
         "common_hidden",
         "debug_hidden",
-        "clang18_hidden"
+        "clang19_hidden"
       ],
-      "displayName": "Clang 18 Debug"
+      "displayName": "Clang 19 Debug"
     },
     {
-      "name": "release_clang18",
+      "name": "release_clang19",
       "inherits": [
         "common_hidden",
         "release_hidden",
-        "clang18_hidden"
+        "clang19_hidden"
       ],
-      "displayName": "Clang 18 RelWithDebInfo"
+      "displayName": "Clang 19 RelWithDebInfo"
     },
     {
-      "name": "asan_clang18",
+      "name": "asan_clang19",
       "inherits": [
         "common_hidden",
         "asan_hidden",
-        "clang18_hidden"
+        "clang19_hidden"
       ],
-      "displayName": "Clang 18 ASan"
+      "displayName": "Clang 19 ASan"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently prebuilt binaries are not available.
 #### Dependencies
 
 - [CMake](https://cmake.org/) 3.20.0+
-- [Clang](https://clang.llvm.org/) (`clang-15` .. `clang-18`) or [GCC](https://gcc.gnu.org/) (`gcc-12` .. `gcc-14`)
+- [Clang](https://clang.llvm.org/) (`clang-15` .. `clang-19`) or [GCC](https://gcc.gnu.org/) (`gcc-12` .. `gcc-14`)
 - [Boost libraries](https://www.boost.org/) 1.88.0 (git version, not the source tarball)
 - [MySQL client library](https://dev.mysql.com/doc/c-api/8.0/en/) 8.0.x (`libmysqlclient`)
 - [CURL library](https://curl.se/libcurl/) (`libcurl`) 8.6.0+
@@ -44,7 +44,7 @@ Define `BUILD_PRESET` depending on whether you want to build in `Debug`, `Releas
 export BUILD_PRESET=<configuration>_<toolset>
 ```
 The supported values for `<configuration>` are `debug`, `release`, and `asan`.
-The supported values for `<toolset>` are `gcc13` and  `clang18`.
+The supported values for `<toolset>` are `gcc13` and  `clang19`.
 
 For instance, if you want to build in `RelWithDebInfo` configuration using `GCC 13`, please specify
 ```bash

--- a/extra/cmake_presets/aws-sdk-cpp/CMakePresets.json
+++ b/extra/cmake_presets/aws-sdk-cpp/CMakePresets.json
@@ -55,11 +55,11 @@
       }
     },
     {
-      "name": "clang18_hidden",
+      "name": "clang19_hidden",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-18",
-        "CMAKE_CXX_COMPILER": "clang++-18",
+        "CMAKE_C_COMPILER": "clang-19",
+        "CMAKE_CXX_COMPILER": "clang++-19",
         "CMAKE_CXX_FLAGS_INIT": "-stdlib=libc++"
       }
     },
@@ -93,31 +93,31 @@
     },
 
     {
-      "name": "debug_clang18",
+      "name": "debug_clang19",
       "inherits": [
         "common_hidden",
         "debug_hidden",
-        "clang18_hidden"
+        "clang19_hidden"
       ],
-      "displayName": "Clang 18 Debug"
+      "displayName": "Clang 19 Debug"
     },
     {
-      "name": "release_clang18",
+      "name": "release_clang19",
       "inherits": [
         "common_hidden",
         "release_hidden",
-        "clang18_hidden"
+        "clang19_hidden"
       ],
-      "displayName": "Clang 18 RelWithDebInfo"
+      "displayName": "Clang 19 RelWithDebInfo"
     },
     {
-      "name": "asan_clang18",
+      "name": "asan_clang19",
       "inherits": [
         "common_hidden",
         "asan_hidden",
-        "clang18_hidden"
+        "clang19_hidden"
       ],
-      "displayName": "Clang 18 ASan"
+      "displayName": "Clang 19 ASan"
     }
   ]
 }

--- a/extra/cmake_presets/boost/CMakePresets.json
+++ b/extra/cmake_presets/boost/CMakePresets.json
@@ -53,11 +53,11 @@
       }
     },
     {
-      "name": "clang18_hidden",
+      "name": "clang19_hidden",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-18",
-        "CMAKE_CXX_COMPILER": "clang++-18"
+        "CMAKE_C_COMPILER": "clang-19",
+        "CMAKE_CXX_COMPILER": "clang++-19"
       },
       "environment": {
         "STDLIB_FLAGS": "-stdlib=libc++"
@@ -93,31 +93,31 @@
     },
 
     {
-      "name": "debug_clang18",
+      "name": "debug_clang19",
       "inherits": [
         "common_hidden",
         "debug_hidden",
-        "clang18_hidden"
+        "clang19_hidden"
       ],
-      "displayName": "Clang 18 Debug"
+      "displayName": "Clang 19 Debug"
     },
     {
-      "name": "release_clang18",
+      "name": "release_clang19",
       "inherits": [
         "common_hidden",
         "release_hidden",
-        "clang18_hidden"
+        "clang19_hidden"
       ],
-      "displayName": "Clang 18 RelWithDebInfo"
+      "displayName": "Clang 19 RelWithDebInfo"
     },
     {
-      "name": "asan_clang18",
+      "name": "asan_clang19",
       "inherits": [
         "common_hidden",
         "asan_hidden",
-        "clang18_hidden"
+        "clang19_hidden"
       ],
-      "displayName": "Clang 18 ASan"
+      "displayName": "Clang 19 ASan"
     }
   ]
 }

--- a/src/binsrv/event/checksum_algorithm_type.hpp
+++ b/src/binsrv/event/checksum_algorithm_type.hpp
@@ -35,6 +35,7 @@ namespace binsrv::event {
 // clang-format on
 
 #define BINSRV_CHECKSUM_ALGORITHM_TYPE_XY_MACRO(X, Y) X = Y
+// NOLINTNEXTLINE(readability-enum-initial-value,cert-int09-c)
 enum class checksum_algorithm_type : std::uint8_t {
   BINSRV_CHECKSUM_ALGORITHM_TYPE_XY_SEQUENCE(),
   delimiter

--- a/src/binsrv/event/checksum_algorithm_type_fwd.hpp
+++ b/src/binsrv/event/checksum_algorithm_type_fwd.hpp
@@ -20,6 +20,7 @@
 
 namespace binsrv::event {
 
+// NOLINTNEXTLINE(readability-enum-initial-value,cert-int09-c)
 enum class checksum_algorithm_type : std::uint8_t;
 
 } // namespace binsrv::event

--- a/src/binsrv/event/code_type.hpp
+++ b/src/binsrv/event/code_type.hpp
@@ -68,6 +68,7 @@ namespace binsrv::event {
 // clang-format on
 
 #define BINSRV_EVENT_CODE_TYPE_XY_MACRO(X, Y) X = Y
+// NOLINTNEXTLINE(readability-enum-initial-value,cert-int09-c)
 enum class code_type : std::uint8_t {
   BINSRV_EVENT_CODE_TYPE_XY_SEQUENCE(),
   delimiter

--- a/src/binsrv/event/code_type_fwd.hpp
+++ b/src/binsrv/event/code_type_fwd.hpp
@@ -20,6 +20,7 @@
 
 namespace binsrv::event {
 
+// NOLINTNEXTLINE(readability-enum-initial-value,cert-int09-c)
 enum class code_type : std::uint8_t;
 
 } // namespace binsrv::event

--- a/src/binsrv/event/flag_type.hpp
+++ b/src/binsrv/event/flag_type.hpp
@@ -50,6 +50,7 @@ namespace binsrv::event {
 // clang-format on
 
 #define BINSRV_EVENT_FLAG_TYPE_XY_MACRO(X, Y) X = Y
+// NOLINTNEXTLINE(readability-enum-initial-value,cert-int09-c)
 enum class flag_type : std::uint16_t {
   BINSRV_EVENT_FLAG_TYPE_XY_SEQUENCE(),
   delimiter

--- a/src/binsrv/event/flag_type_fwd.hpp
+++ b/src/binsrv/event/flag_type_fwd.hpp
@@ -22,6 +22,7 @@
 
 namespace binsrv::event {
 
+// NOLINTNEXTLINE(readability-enum-initial-value,cert-int09-c)
 enum class flag_type : std::uint16_t;
 
 using flag_set = util::flag_set<flag_type>;


### PR DESCRIPTION
CMake presets for Boost, AWS SDK C++ and the main projects now use 'clang-19'.

GitHub Actions scripts now use 'clang19_xxx' presets instead of 'clang1_xxx'.

Clang Format and Clang Tidy invocations in GitHub Actions scripts changed to version 19.

Fixed new clang-19-specific Clang Tidy warnings in the source code.

Verified that "-stdlib=libc++ -fsanitize=address" alloc-dealloc-mismatch issue (https://github.com/llvm/llvm-project/issues/59432) still exists in Clang 19 - updated TODO item to try again in Clang 20.