### PR TITLE
Updated gcc toolset to version 14

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -58,18 +58,18 @@ jobs:
       matrix:
         config:
         - {
-            name: "GCC 13 Debug",
-            label: "debug_gcc13",
+            name: "GCC 14 Debug",
+            label: "debug_gcc14",
             run_mtr: true
           }
         - {
-            name: "GCC 13 RelWithDebInfo",
-            label: "release_gcc13",
+            name: "GCC 14 RelWithDebInfo",
+            label: "release_gcc14",
             run_mtr: true
           }
         - {
-            name: "GCC 13 ASan",
-            label: "asan_gcc13",
+            name: "GCC 14 ASan",
+            label: "asan_gcc14",
             run_mtr: true,
             mtr_options: "--sanitize"
           }
@@ -133,7 +133,7 @@ jobs:
       if: startsWith(matrix.config.name, 'GCC')
       run: |
         sudo apt-get update
-        sudo apt-get install g++-13
+        sudo apt-get install g++-14
 
     - name: Info CMake
       run: cmake --version

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -43,11 +43,11 @@
     },
 
     {
-      "name": "gcc13_hidden",
+      "name": "gcc14_hidden",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "gcc-13",
-        "CMAKE_CXX_COMPILER": "g++-13"
+        "CMAKE_C_COMPILER": "gcc-14",
+        "CMAKE_CXX_COMPILER": "g++-14"
       }
     },
     {
@@ -61,31 +61,31 @@
     },
 
     {
-      "name": "debug_gcc13",
+      "name": "debug_gcc14",
       "inherits": [
         "common_hidden",
         "debug_hidden",
-        "gcc13_hidden"
+        "gcc14_hidden"
       ],
-      "displayName": "GCC 13 Debug"
+      "displayName": "GCC 14 Debug"
     },
     {
-      "name": "release_gcc13",
+      "name": "release_gcc14",
       "inherits": [
         "common_hidden",
         "release_hidden",
-        "gcc13_hidden"
+        "gcc14_hidden"
       ],
-      "displayName": "GCC 13 RelWithDebInfo"
+      "displayName": "GCC 14 RelWithDebInfo"
     },
     {
-      "name": "asan_gcc13",
+      "name": "asan_gcc14",
       "inherits": [
         "common_hidden",
         "asan_hidden",
-        "gcc13_hidden"
+        "gcc14_hidden"
       ],
-      "displayName": "GCC 13 ASan"
+      "displayName": "GCC 14 ASan"
     },
 
     {

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Define `BUILD_PRESET` depending on whether you want to build in `Debug`, `Releas
 export BUILD_PRESET=<configuration>_<toolset>
 ```
 The supported values for `<configuration>` are `debug`, `release`, and `asan`.
-The supported values for `<toolset>` are `gcc13` and  `clang19`.
+The supported values for `<toolset>` are `gcc14` and  `clang19`.
 
-For instance, if you want to build in `RelWithDebInfo` configuration using `GCC 13`, please specify
+For instance, if you want to build in `RelWithDebInfo` configuration using `GCC 14`, please specify
 ```bash
-export BUILD_PRESET=release_gcc13
+export BUILD_PRESET=release_gcc14
 ```
 
 ##### Boost Libraries

--- a/extra/cmake_presets/aws-sdk-cpp/CMakePresets.json
+++ b/extra/cmake_presets/aws-sdk-cpp/CMakePresets.json
@@ -47,11 +47,11 @@
     },
 
     {
-      "name": "gcc13_hidden",
+      "name": "gcc14_hidden",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "gcc-13",
-        "CMAKE_CXX_COMPILER": "g++-13"
+        "CMAKE_C_COMPILER": "gcc-14",
+        "CMAKE_CXX_COMPILER": "g++-14"
       }
     },
     {
@@ -65,31 +65,31 @@
     },
 
     {
-      "name": "debug_gcc13",
+      "name": "debug_gcc14",
       "inherits": [
         "common_hidden",
         "debug_hidden",
-        "gcc13_hidden"
+        "gcc14_hidden"
       ],
-      "displayName": "GCC 13 Debug"
+      "displayName": "GCC 14 Debug"
     },
     {
-      "name": "release_gcc13",
+      "name": "release_gcc14",
       "inherits": [
         "common_hidden",
         "release_hidden",
-        "gcc13_hidden"
+        "gcc14_hidden"
       ],
-      "displayName": "GCC 13 RelWithDebInfo"
+      "displayName": "GCC 14 RelWithDebInfo"
     },
     {
-      "name": "asan_gcc13",
+      "name": "asan_gcc14",
       "inherits": [
         "common_hidden",
         "asan_hidden",
-        "gcc13_hidden"
+        "gcc14_hidden"
       ],
-      "displayName": "GCC 13 ASan"
+      "displayName": "GCC 14 ASan"
     },
 
     {

--- a/extra/cmake_presets/boost/CMakePresets.json
+++ b/extra/cmake_presets/boost/CMakePresets.json
@@ -45,11 +45,11 @@
     },
 
     {
-      "name": "gcc13_hidden",
+      "name": "gcc14_hidden",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "gcc-13",
-        "CMAKE_CXX_COMPILER": "g++-13"
+        "CMAKE_C_COMPILER": "gcc-14",
+        "CMAKE_CXX_COMPILER": "g++-14"
       }
     },
     {
@@ -65,31 +65,31 @@
     },
 
     {
-      "name": "debug_gcc13",
+      "name": "debug_gcc14",
       "inherits": [
         "common_hidden",
         "debug_hidden",
-        "gcc13_hidden"
+        "gcc14_hidden"
       ],
-      "displayName": "GCC 13 Debug"
+      "displayName": "GCC 14 Debug"
     },
     {
-      "name": "release_gcc13",
+      "name": "release_gcc14",
       "inherits": [
         "common_hidden",
         "release_hidden",
-        "gcc13_hidden"
+        "gcc14_hidden"
       ],
-      "displayName": "GCC 13 RelWithDebInfo"
+      "displayName": "GCC 14 RelWithDebInfo"
     },
     {
-      "name": "asan_gcc13",
+      "name": "asan_gcc14",
       "inherits": [
         "common_hidden",
         "asan_hidden",
-        "gcc13_hidden"
+        "gcc14_hidden"
       ],
-      "displayName": "GCC 13 ASan"
+      "displayName": "GCC 14 ASan"
     },
 
     {


### PR DESCRIPTION
CMake presets for Boost, AWS SDK C++ and the main projects now use 'gcc-194.

GitHub Actions scripts now use 'clang14_xxx' presets instead of 'clang13_xxx'.