### PR TITLE
PS-10007 feature: Implemented support for MySQL Server 8.4 series

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,10 @@ set(source_files
   src/binsrv/event/rotate_post_header_impl.hpp
   src/binsrv/event/rotate_post_header_impl.cpp
 
+  src/binsrv/event/server_version_fwd.hpp
+  src/binsrv/event/server_version.hpp
+  src/binsrv/event/server_version.cpp
+
   src/binsrv/event/stop_body_impl_fwd.hpp
   src/binsrv/event/stop_body_impl.hpp
 

--- a/mtr/binlog_streaming/include/v80_v84_compatibility_defines.inc
+++ b/mtr/binlog_streaming/include/v80_v84_compatibility_defines.inc
@@ -1,0 +1,24 @@
+--let $lts_series = unknown
+if (`SELECT VERSION() LIKE '8.0%'`)
+{
+  --let $lts_series = v80
+}
+if (`SELECT VERSION() LIKE '8.4%'`)
+{
+  --let $lts_series = v84
+}
+
+if ($lts_series == unknown)
+{
+  --die unsupported MySQL Server version
+}
+if ($lts_series == v80)
+{
+  --let $stmt_reset_binary_logs_and_gtids = RESET MASTER
+  --let $stmt_show_binary_log_status = SHOW MASTER STATUS
+}
+if ($lts_series == v84)
+{
+  --let $stmt_reset_binary_logs_and_gtids = RESET BINARY LOGS AND GTIDS
+  --let $stmt_show_binary_log_status = SHOW BINARY LOG STATUS
+}

--- a/mtr/binlog_streaming/r/binsrv.result
+++ b/mtr/binlog_streaming/r/binsrv.result
@@ -1,5 +1,4 @@
 *** Resetting replication at the very beginning of the test.
-RESET MASTER;
 
 *** Determining the first fresh binary log name.
 

--- a/mtr/binlog_streaming/r/pull_mode.result
+++ b/mtr/binlog_streaming/r/pull_mode.result
@@ -1,5 +1,4 @@
 *** Resetting replication at the very beginning of the test.
-RESET MASTER;
 
 *** Generating a configuration file in JSON format for the Binlog
 *** Server utility.

--- a/mtr/binlog_streaming/t/binsrv.test
+++ b/mtr/binlog_streaming/t/binsrv.test
@@ -4,14 +4,18 @@ if (!$BINSRV) {
   --skip \$BINSRV environment variable must be set
 }
 
+--source ../include/v80_v84_compatibility_defines.inc
+
 # in case of --repeat=N, we need to start from a fresh binary log to make
 # this test deterministic
 --echo *** Resetting replication at the very beginning of the test.
-RESET MASTER;
+--disable_query_log
+eval $stmt_reset_binary_logs_and_gtids;
+--enable_query_log
 
 --echo
 --echo *** Determining the first fresh binary log name.
---let $first_binlog = query_get_value(SHOW MASTER STATUS, File, 1)
+--let $first_binlog = query_get_value($stmt_show_binary_log_status, File, 1)
 
 --echo
 --echo *** Creating a simple table and filling it with some data.
@@ -24,7 +28,7 @@ FLUSH BINARY LOGS;
 
 --echo
 --echo *** Determining the second binary log name.
---let $second_binlog = query_get_value(SHOW MASTER STATUS, File, 1)
+--let $second_binlog = query_get_value($stmt_show_binary_log_status, File, 1)
 
 --echo
 --echo *** Filling the table with some more data.

--- a/mtr/binlog_streaming/t/pull_mode.test
+++ b/mtr/binlog_streaming/t/pull_mode.test
@@ -4,12 +4,16 @@ if (!$BINSRV) {
   --skip \$BINSRV environment variable must be set
 }
 
+--source ../include/v80_v84_compatibility_defines.inc
+
 --source include/count_sessions.inc
 
 # in case of --repeat=N, we need to start from a fresh binary log to make
 # this test deterministic
 --echo *** Resetting replication at the very beginning of the test.
-RESET MASTER;
+--disable_query_log
+eval $stmt_reset_binary_logs_and_gtids;
+--enable_query_log
 
 # identifying backend storage type ('file' or 's3')
 --source ../include/identify_storage_backend.inc
@@ -39,7 +43,7 @@ EOF
 
 --echo
 --echo *** Determining the first fresh binary log name.
---let $first_binlog = query_get_value(SHOW MASTER STATUS, File, 1)
+--let $first_binlog = query_get_value($stmt_show_binary_log_status, File, 1)
 
 --echo
 --echo *** Creating a simple table and filling it with some data.
@@ -57,7 +61,7 @@ INSERT INTO t1 VALUES(DEFAULT);
 
 --echo
 --echo *** Determining the second binary log name.
---let $second_binlog = query_get_value(SHOW MASTER STATUS, File, 1)
+--let $second_binlog = query_get_value($stmt_show_binary_log_status, File, 1)
 
 --echo
 --echo *** Filling the table with some more data.
@@ -74,7 +78,7 @@ INSERT INTO t1 VALUES(DEFAULT);
 
 --echo
 --echo *** Determining the third binary log name.
---let $third_binlog = query_get_value(SHOW MASTER STATUS, File, 1)
+--let $third_binlog = query_get_value($stmt_show_binary_log_status, File, 1)
 
 --echo
 --echo *** Filling the table with some more data again and dropping the table.
@@ -88,7 +92,7 @@ FLUSH BINARY LOGS;
 
 --echo
 --echo *** Determining the fourth binary log name.
---let $fourth_binlog = query_get_value(SHOW MASTER STATUS, File, 1)
+--let $fourth_binlog = query_get_value($stmt_show_binary_log_status, File, 1)
 
 --echo
 --echo *** Waiting till Binlog Server Utility starts processing the fourth

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -302,6 +302,7 @@ void receive_binlog_events(
   //       @source_binlog_checksum variable that we set in the
   //       'connection::switch_to_replication()'
   binsrv::event::reader_context context{
+      connection.get_server_version(),
       binsrv::event::checksum_algorithm_type::off};
 
   // if binlog is still open, there is no sense to close it and re-open

--- a/src/binsrv/event/checksum_algorithm_type.hpp
+++ b/src/binsrv/event/checksum_algorithm_type.hpp
@@ -27,7 +27,8 @@ namespace binsrv::event {
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 // Checksum algorithm type codes copied from
-// https://github.com/mysql/mysql-server/blob/mysql-8.0.37/libbinlogevents/include/binlog_event.h#L426
+// https://github.com/mysql/mysql-server/blob/mysql-8.0.43/libbinlogevents/include/binlog_event.h#L440
+// https://github.com/mysql/mysql-server/blob/mysql-8.4.6/libs/mysql/binlog/event/binlog_event.h#L462
 // clang-format off
 #define BINSRV_CHECKSUM_ALGORITHM_TYPE_XY_SEQUENCE() \
   BINSRV_CHECKSUM_ALGORITHM_TYPE_XY_MACRO(off  ,  0), \

--- a/src/binsrv/event/code_type.hpp
+++ b/src/binsrv/event/code_type.hpp
@@ -27,7 +27,8 @@ namespace binsrv::event {
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 // Event type codes copied from
-// https://github.com/mysql/mysql-server/blob/mysql-8.0.37/libbinlogevents/include/binlog_event.h#L275
+// https://github.com/mysql/mysql-server/blob/mysql-8.0.43/libbinlogevents/include/binlog_event.h#L275
+// https://github.com/mysql/mysql-server/blob/mysql-8.4.6/libs/mysql/binlog/event/binlog_event.h#L286
 // clang-format off
 #define BINSRV_EVENT_CODE_TYPE_XY_SEQUENCE() \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(unknown            ,  0), \
@@ -36,9 +37,13 @@ namespace binsrv::event {
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(stop               ,  3), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(rotate             ,  4), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(intvar             ,  5), \
+  BINSRV_EVENT_CODE_TYPE_XY_MACRO(obsolete_6         ,  6), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(slave              ,  7), \
+  BINSRV_EVENT_CODE_TYPE_XY_MACRO(obsolete_8         ,  8), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(append_block       ,  9), \
+  BINSRV_EVENT_CODE_TYPE_XY_MACRO(obsolete_10        , 10), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(delete_file        , 11), \
+  BINSRV_EVENT_CODE_TYPE_XY_MACRO(obsolete_12        , 12), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(rand               , 13), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(user_var           , 14), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(format_description , 15), \
@@ -46,6 +51,9 @@ namespace binsrv::event {
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(begin_load_query   , 17), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(execute_load_query , 18), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(table_map          , 19), \
+  BINSRV_EVENT_CODE_TYPE_XY_MACRO(obsolete_20        , 20), \
+  BINSRV_EVENT_CODE_TYPE_XY_MACRO(obsolete_21        , 21), \
+  BINSRV_EVENT_CODE_TYPE_XY_MACRO(obsolete_22        , 22), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(write_rows_v1      , 23), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(update_rows_v1     , 24), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(delete_rows_v1     , 25), \
@@ -64,7 +72,8 @@ namespace binsrv::event {
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(xa_prepare_log     , 38), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(partial_update_rows, 39), \
   BINSRV_EVENT_CODE_TYPE_XY_MACRO(transaction_payload, 40), \
-  BINSRV_EVENT_CODE_TYPE_XY_MACRO(heartbeat_log_v2   , 41)
+  BINSRV_EVENT_CODE_TYPE_XY_MACRO(heartbeat_log_v2   , 41), \
+  BINSRV_EVENT_CODE_TYPE_XY_MACRO(gtid_tagged_log    , 42)
 // clang-format on
 
 #define BINSRV_EVENT_CODE_TYPE_XY_MACRO(X, Y) X = Y

--- a/src/binsrv/event/common_header.cpp
+++ b/src/binsrv/event/common_header.cpp
@@ -40,7 +40,8 @@ common_header::common_header(util::const_byte_span portion) {
   // TODO: rework with direct member initialization
 
   /*
-    https://github.com/mysql/mysql-server/blob/mysql-8.0.37/libbinlogevents/src/binlog_event.cpp#L198
+    https://github.com/mysql/mysql-server/blob/mysql-8.0.43/libbinlogevents/src/binlog_event.cpp#L198
+    https://github.com/mysql/mysql-server/blob/mysql-8.4.6/libs/mysql/binlog/event/binlog_event.cpp#L242
 
     The first 19 bytes in the header is as follows:
       +============================================+

--- a/src/binsrv/event/flag_type.hpp
+++ b/src/binsrv/event/flag_type.hpp
@@ -29,9 +29,11 @@ namespace binsrv::event {
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 // Event flags copied from
-// https://github.com/mysql/mysql-server/blob/mysql-8.0.37/sql/log_event.h#L247
+// https://github.com/mysql/mysql-server/blob/mysql-8.0.43/sql/log_event.h#L247
+// https://github.com/mysql/mysql-server/blob/mysql-8.4.6/sql/log_event.h#L245
 // 'binlog_in_use' flag is copied from
-// https://github.com/mysql/mysql-server/blob/mysql-8.0.37/libbinlogevents/include/binlog_event.h#L270
+// https://github.com/mysql/mysql-server/blob/mysql-8.0.43/libbinlogevents/include/binlog_event.h#L270
+// https://github.com/mysql/mysql-server/blob/mysql-8.4.6/libs/mysql/binlog/event/binlog_event.h#L281
 // This flag is used as a marker in the common header section of the very
 // first format description event that this particular binlog is currently in
 // use. It us cleared(rewritten) by the server when the binary log is

--- a/src/binsrv/event/protocol_traits.hpp
+++ b/src/binsrv/event/protocol_traits.hpp
@@ -30,17 +30,20 @@ using encoded_post_header_length_type = std::uint8_t;
 
 // we do not store length for the first element which is the "unknown" event
 using post_header_length_container =
-    std::array<encoded_post_header_length_type, default_number_of_events - 1U>;
+    std::array<encoded_post_header_length_type, max_number_of_events - 1U>;
 
 [[nodiscard]] std::size_t
-get_post_header_length_for_code(const post_header_length_container &storage,
+get_post_header_length_for_code(std::uint32_t encoded_server_version,
+                                const post_header_length_container &storage,
                                 code_type code) noexcept;
 
 std::ostream &
 print_post_header_lengths(std::ostream &output,
+                          std::uint32_t encoded_server_version,
                           const post_header_length_container &obj);
 
 void validate_post_header_lengths(
+    std::uint32_t encoded_server_version,
     const post_header_length_container &runtime,
     const post_header_length_container &hardcoded);
 

--- a/src/binsrv/event/protocol_traits_fwd.hpp
+++ b/src/binsrv/event/protocol_traits_fwd.hpp
@@ -16,6 +16,7 @@
 #ifndef BINSRV_EVENT_PROTOCOL_TRAITS_FWD_HPP
 #define BINSRV_EVENT_PROTOCOL_TRAITS_FWD_HPP
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -25,13 +26,40 @@
 namespace binsrv::event {
 
 inline constexpr std::uint16_t default_binlog_version{4U};
-inline constexpr std::size_t default_number_of_events{42U};
+
+inline constexpr std::uint32_t lts80_protocol_server_version{80000U};
+inline constexpr std::uint32_t
+    innovation83_with_tagged_gtids_protocol_server_version{80300U};
+
+inline constexpr std::uint32_t earliest_supported_protocol_server_version{
+    lts80_protocol_server_version};
+inline constexpr std::uint32_t latest_known_protocol_server_version{
+    innovation83_with_tagged_gtids_protocol_server_version};
+
+inline constexpr std::uint32_t lts80_number_of_events{42U};
+inline constexpr std::uint32_t innovation83_with_tagged_gtids_number_of_events{
+    43U};
+
+constexpr std::size_t
+get_number_of_events(std::uint32_t encoded_server_version) noexcept {
+  // Tagged GTIDs alomng with new new tagged GTID event were introduced in
+  // MySQL Server 8.3.0 Innovation.
+  // This new event incresed the size of post header length table in FDE.
+  return encoded_server_version < latest_known_protocol_server_version
+             ? lts80_number_of_events
+             : innovation83_with_tagged_gtids_number_of_events;
+}
+
+inline constexpr std::size_t max_number_of_events{
+    std::max(get_number_of_events(earliest_supported_protocol_server_version),
+             get_number_of_events(latest_known_protocol_server_version))};
 inline constexpr std::size_t default_common_header_length{19U};
 
 inline constexpr std::size_t unspecified_post_header_length{
     std::numeric_limits<std::size_t>::max()};
 
-// https://github.com/mysql/mysql-server/blob/trunk/sql/log_event.h#L211
+// https://github.com/mysql/mysql-server/blob/mysql-8.0.43/sql/log_event.h#L215
+// https://github.com/mysql/mysql-server/blob/mysql-8.4.6/sql/log_event.h#L213
 // 4 bytes which all binlogs should begin with
 inline constexpr std::array<std::byte, 4> magic_binlog_payload{
     std::byte{0xFE}, std::byte{0x62}, std::byte{0x69}, std::byte{0x6E}};

--- a/src/binsrv/event/reader_context.hpp
+++ b/src/binsrv/event/reader_context.hpp
@@ -31,8 +31,13 @@ class [[nodiscard]] reader_context {
   friend class event;
 
 public:
-  explicit reader_context(checksum_algorithm_type checksum_algorithm);
+  reader_context(std::uint32_t encoded_server_version,
+                 checksum_algorithm_type checksum_algorithm);
 
+  [[nodiscard]] std::uint32_t
+  get_current_encoded_server_version() const noexcept {
+    return encoded_server_version_;
+  }
   [[nodiscard]] checksum_algorithm_type
   get_current_checksum_algorithm() const noexcept;
   [[nodiscard]] std::size_t
@@ -50,6 +55,7 @@ private:
     format_description_processed
   };
   state_type state_{state_type::initial};
+  std::uint32_t encoded_server_version_;
   checksum_algorithm_type checksum_algorithm_;
   post_header_length_container post_header_lengths_{};
   std::uint32_t position_{0U};
@@ -61,6 +67,10 @@ private:
   [[nodiscard]] bool process_event_in_format_description_processed_state(
       const event &current_event);
   void validate_position_and_advance(const common_header &common_header);
+
+  [[nodiscard]] static const post_header_length_container &
+  get_hardcoded_post_header_lengths(
+      std::uint32_t encoded_server_version) noexcept;
 };
 
 } // namespace binsrv::event

--- a/src/binsrv/event/rotate_post_header_impl.cpp
+++ b/src/binsrv/event/rotate_post_header_impl.cpp
@@ -34,7 +34,8 @@ generic_post_header_impl<code_type::rotate>::generic_post_header_impl(
   // TODO: rework with direct member initialization
 
   /*
-    https://github.com/mysql/mysql-server/blob/mysql-8.0.37/libbinlogevents/include/control_events.h#L54
+    https://github.com/mysql/mysql-server/blob/mysql-8.0.43/libbinlogevents/include/control_events.h#L54
+    https://github.com/mysql/mysql-server/blob/mysql-8.4.6/libs/mysql/binlog/event/control_events.h#L62
 
     <table>
     <caption>Post-Header for Rotate_event</caption>

--- a/src/binsrv/event/server_version.cpp
+++ b/src/binsrv/event/server_version.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#include "binsrv/event/server_version.hpp"
+
+#include <charconv>
+#include <cstdint>
+#include <ranges>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "util/exception_location_helpers.hpp"
+
+namespace binsrv::event {
+
+server_version::server_version(std::string_view version_string)
+    : major_{}, minor_{}, patch_{} {
+  const auto dash_pos{version_string.find('-')};
+  if (dash_pos != std::string::npos) {
+    version_string.remove_suffix(version_string.size() - dash_pos);
+  }
+  auto split_result{std::ranges::views::split(version_string, '.')};
+  auto version_it{std::ranges::begin(split_result)};
+  const auto version_en{std::ranges::end(split_result)};
+
+  const auto component_extractor{
+      [version_en](auto &cuttent_it, const std::string &name) -> std::uint8_t {
+        if (cuttent_it == version_en) {
+          util::exception_location().raise<std::invalid_argument>(
+              "server_version does not have the \"" + name + "\" component");
+        }
+        std::uint8_t result{};
+        const auto component_it{std::ranges::cbegin(*cuttent_it)};
+        const auto component_en{std::ranges::cend(*cuttent_it)};
+        const auto [conversion_ptr, conversion_ec]{
+            std::from_chars(component_it, component_en, result)};
+        if (conversion_ec != std::errc{} || conversion_ptr != component_en) {
+          util::exception_location().raise<std::invalid_argument>(
+              "server_version \"" + name +
+              "\" component is not a numeric value");
+        }
+        ++cuttent_it;
+        return result;
+      }};
+  major_ = component_extractor(version_it, "major");
+  minor_ = component_extractor(version_it, "minor");
+  patch_ = component_extractor(version_it, "patch");
+  if (version_it != version_en) {
+    util::exception_location().raise<std::invalid_argument>(
+        "server_version has more than 3 components");
+  }
+}
+
+} // namespace binsrv::event

--- a/src/binsrv/event/server_version.hpp
+++ b/src/binsrv/event/server_version.hpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#ifndef BINSRV_EVENT_SERVER_VERSION_HPP
+#define BINSRV_EVENT_SERVER_VERSION_HPP
+
+#include "binsrv/event/server_version_fwd.hpp" // IWYU pragma: export
+
+#include <cstdint>
+#include <string_view>
+
+namespace binsrv::event {
+
+class [[nodiscard]] server_version {
+private:
+  static constexpr std::uint32_t minor_multiplier{100U};
+  static constexpr std::uint32_t major_multiplier{minor_multiplier *
+                                                  minor_multiplier};
+
+public:
+  constexpr explicit server_version(
+      std::uint32_t encoded_server_version) noexcept
+      : major_{static_cast<std::uint8_t>(encoded_server_version /
+                                         major_multiplier % minor_multiplier)},
+        minor_{static_cast<std::uint8_t>(encoded_server_version /
+                                         minor_multiplier % minor_multiplier)},
+        patch_{static_cast<std::uint8_t>(encoded_server_version %
+                                         minor_multiplier)} {}
+
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  constexpr server_version(std::uint8_t major, std::uint8_t minor,
+                           std::uint8_t patch) noexcept
+      : major_{major}, minor_{minor}, patch_{patch} {}
+  explicit server_version(std::string_view version_string);
+
+  [[nodiscard]] constexpr std::uint8_t get_major() const noexcept {
+    return major_;
+  }
+  [[nodiscard]] constexpr std::uint8_t get_minor() const noexcept {
+    return minor_;
+  }
+  [[nodiscard]] constexpr std::uint8_t get_patch() const noexcept {
+    return patch_;
+  }
+
+  [[nodiscard]] constexpr std::uint32_t get_encoded() const noexcept {
+    return (major_ * major_multiplier) + (minor_ * minor_multiplier) + patch_;
+  }
+
+  [[nodiscard]] friend constexpr auto
+  operator<=>(const server_version &first,
+              const server_version &second) = default;
+
+private:
+  std::uint8_t major_;
+  std::uint8_t minor_;
+  std::uint8_t patch_;
+};
+
+} // namespace binsrv::event
+
+#endif // BINSRV_EVENT_SERVER_VERSION_HPP

--- a/src/binsrv/event/server_version_fwd.hpp
+++ b/src/binsrv/event/server_version_fwd.hpp
@@ -13,17 +13,13 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-#ifndef BINSRV_EVENT_EVENT_FWD_HPP
-#define BINSRV_EVENT_EVENT_FWD_HPP
-
-#include <iosfwd>
+#ifndef BINSRV_EVENT_SERVER_VERSION_FWD_HPP
+#define BINSRV_EVENT_SERVER_VERSION_FWD_HPP
 
 namespace binsrv::event {
 
-class event;
-
-std::ostream &operator<<(std::ostream &output, const event &obj);
+class server_version;
 
 } // namespace binsrv::event
 
-#endif // BINSRV_EVENT_EVENT_FWD_HPP
+#endif // BINSRV_EVENT_SERVER_VERSION_FWD_HPP

--- a/src/easymysql/connection.cpp
+++ b/src/easymysql/connection.cpp
@@ -84,14 +84,18 @@ private:
   MYSQL_RPL rpl_;
 
   // MYSQL_RPL_SKIP_HEARTBEAT
-  // https://github.com/mysql/mysql-server/blob/mysql-cluster-8.0.37/include/mysql.h#L366
+  // https://github.com/mysql/mysql-server/blob/mysql-cluster-8.0.43/include/mysql.h#L366
+  // https://github.com/mysql/mysql-server/blob/mysql-cluster-8.4.6/include/mysql.h#L367
 
   // USE_HEARTBEAT_EVENT_V2
-  // https://github.com/mysql/mysql-server/blob/mysql-cluster-8.0.37/include/mysql.h#L372
+  // https://github.com/mysql/mysql-server/blob/mysql-cluster-8.0.43/include/mysql.h#L372
+  // https://github.com/mysql/mysql-server/blob/mysql-cluster-8.4.6/include/mysql.h#L373
 
   // Explaining BINLOG_DUMP_NON_BLOCK
-  // https://github.com/mysql/mysql-server/blob/mysql-8.0.37/sql/rpl_constants.h#L45
-  // https://github.com/mysql/mysql-server/blob/mysql-8.0.37/sql/rpl_binlog_sender.cc#L313
+  // https://github.com/mysql/mysql-server/blob/mysql-8.0.43/sql/rpl_constants.h#L45
+  // https://github.com/mysql/mysql-server/blob/mysql-8.4.6/sql/rpl_constants.h#L45
+  // https://github.com/mysql/mysql-server/blob/mysql-8.0.43/sql/rpl_binlog_sender.cc#L313
+  // https://github.com/mysql/mysql-server/blob/mysql-8.4.6/sql/rpl_binlog_sender.cc#L320
 
   // For some reason BINLOG_DUMP_NON_BLOCK is a private constant, defining is
   // locally

--- a/src/util/byte_span_extractors.hpp
+++ b/src/util/byte_span_extractors.hpp
@@ -42,6 +42,17 @@ void extract_fixed_int_from_byte_span(util::const_byte_span &remainder,
   remainder = remainder.subspan(sizeof(T));
 }
 
+template <typename T>
+  requires(std::integral<T> || std::same_as<T, std::byte>) && (sizeof(T) == 1U)
+void extract_byte_span_from_byte_span(util::const_byte_span &remainder,
+                                      std::span<T> storage_span) noexcept {
+  assert(std::size(remainder) >= storage_span.size());
+  std::memcpy(std::data(storage_span), std::data(remainder),
+              storage_span.size());
+
+  remainder = remainder.subspan(storage_span.size());
+}
+
 template <typename T, std::size_t N>
   requires(std::integral<T> || std::same_as<T, std::byte>) && (sizeof(T) == 1U)
 void extract_byte_array_from_byte_span(util::const_byte_span &remainder,


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10007

Added support for binary log events generated by MySQL Server 8.4 LTS. In particular:
* 'GTID TAGGED' binlog event (which is specific to 8.4 series) is now recognized and handled properly by the parser.
* Internal event class representing 'FORMAT DESCRIPTION' binlog event can now handle both 8.0 and 8.4 data. In particular in 8.4, the size of the 'common_header_length' array is increased by 1 because of the additional 'GTID TAGGED'.

'binsrv::event::reader_context' class constructor now takes one more parameter 'encoded_server_version' in order to be aware of 8.0/8.4 differences. The value that is passeed as this 'encoded_server_version' argument is extracted from the 'easymysql::connection' object.

Added 'binsrv::event::server_version' class that helps parse / compose MySQL Server version strings in the '<major>.<minor>.<patch>-<extra>' format.

Generalized MTR test cases so that they can be run on both 8.0 and 8.4 MySQL Servers.

Reference links updated to point to the 'mysql-8.0.43' code. Added reference links to the 'mysql-8.4.6' code.