### PR TITLE
PS-10006 feature: Implement binlog event checksum validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,9 @@ set(source_files
   src/util/composite_name_fwd.hpp
   src/util/composite_name.hpp
 
+  src/util/crc_helpers.hpp
+  src/util/crc_helpers.cpp
+
   src/util/ct_string.hpp
 
   src/util/exception_location_helpers.hpp
@@ -277,6 +280,7 @@ target_link_libraries(binlog_server
     binlog_server_compiler_flags
   PRIVATE
     Boost::headers Boost::url
+    ZLIB::ZLIB
     MySQL::client
     aws-cpp-sdk-s3-crt
 )

--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ The Percona Binary Log Server configuration file has the following format.
   },
   "replication": {
     "server_id": 42,
-    "idle_time": 10
+    "idle_time": 10,
+    "verify_checksum": true
   },
   "storage": {
     "uri": "file:///home/user/vault"
@@ -224,6 +225,7 @@ Currently we use the following mapping:
 #### \<replication\> section
 - `<replication.server_id>` - specifies the server ID that the utility will be using when connecting to a remote MySQL server (similar to [--connection-server-id](https://dev.mysql.com/doc/refman/8.0/en/mysqlbinlog.html#option_mysqlbinlog_connection-server-id) `mysqlbinlog` command line option).
 - `<replication.idle_time>` - the number of seconds the utility will spend in disconnected mode between reconnection attempts.
+- `<replication.verify_checksum>` - a boolean value which specifies whether the utility should verify event checksums.
 
 #### \<storage\> section
 - `<storage.uri>` - specifies the location (either local or remote) where the received binary logs should be stored

--- a/main_config.json
+++ b/main_config.json
@@ -14,7 +14,8 @@
   },
   "replication": {
     "server_id": 42,
-    "idle_time": 10
+    "idle_time": 10,
+    "verify_checksum": true
   },
   "storage": {
     "uri": "file:///home/user/vault"

--- a/mtr/binlog_streaming/include/extract_init_connect_variable_value.inc
+++ b/mtr/binlog_streaming/include/extract_init_connect_variable_value.inc
@@ -1,0 +1,38 @@
+#
+# Extracts the value of the variable set via --init-connect command line
+# option.
+#
+# Usage:
+#   Put
+#     init-connect = SET @foo = bar
+#   into the .opt or .cnf file
+#   ...
+#   --let $extracted_init_connect_variable_name = foo
+#   --source extract_init_connect_variable_value.inc
+#   --echo $extracted_init_connect_variable_value
+#
+# $extracted_init_connect_variable_name  - the name of the variable to
+#                                          extract the value from
+# $extracted_init_connect_variable_value - the MTR variable which will hold
+#                                          the result value
+
+# Because, "--init-connect" statemenmt is executed only for non-privileged
+# users, we need to create one here and read the value of the variable from a new
+# connection established with this user's credentials.
+--disable_query_log
+CREATE USER nonpriv@localhost;
+--enable_query_log
+
+--source include/count_sessions.inc
+
+--connect(con0,localhost,nonpriv)
+--let $extracted_init_connect_variable_value = `SELECT @$extracted_init_connect_variable_name`
+
+--disconnect con0
+--connection default
+
+--source include/wait_until_count_sessions.inc
+
+--disable_query_log
+DROP USER nonpriv@localhost;
+--enable_query_log

--- a/mtr/binlog_streaming/include/set_up_binsrv_environment.inc
+++ b/mtr/binlog_streaming/include/set_up_binsrv_environment.inc
@@ -5,6 +5,7 @@
 #   --let $binsrv_connect_timeout = 20
 #   --let $binsrv_read_timeout = 60
 #   --let $binsrv_idle_time = 10
+#   --let $binsrv_verify_checksum = TRUE | FALSE
 #   --source set_up_binsrv_environment.inc
 
 --echo
@@ -58,7 +59,8 @@ eval SET @binsrv_config_json = JSON_OBJECT(
   ),
   'replication', JSON_OBJECT(
      'server_id', @@server_id + 1,
-     'idle_time', $binsrv_idle_time
+     'idle_time', $binsrv_idle_time,
+     'verify_checksum', $binsrv_verify_checksum
   ),
   'storage', JSON_OBJECT(
      'uri', @storage_uri

--- a/mtr/binlog_streaming/t/binsrv.combinations
+++ b/mtr/binlog_streaming/t/binsrv.combinations
@@ -1,5 +1,15 @@
-[crc]
-binlog_checksum = CRC32
+[srv_nocrc_utl_nocrc]
+binlog-checksum = NONE
+init-connect = SET @binsrv_checksum = 'FALSE'
 
-[nocrc]
-binlog_checksum = NONE
+[srv_nocrc_utl_crc]
+binlog-checksum = NONE
+init-connect = SET @binsrv_checksum = 'TRUE'
+
+[srv_crc_utl_nocrc]
+binlog-checksum = CRC32
+init-connect = SET @binsrv_checksum = 'FALSE'
+
+[srv_crc_utl_crc]
+binlog-checksum = CRC32
+init-connect = SET @binsrv_checksum = 'TRUE'

--- a/mtr/binlog_streaming/t/binsrv.test
+++ b/mtr/binlog_streaming/t/binsrv.test
@@ -37,10 +37,15 @@ INSERT INTO t1 VALUES(DEFAULT);
 # identifying backend storage type ('file' or 's3')
 --source ../include/identify_storage_backend.inc
 
+# identifying utility checksum mode from the conbination
+--let $extracted_init_connect_variable_name = binsrv_checksum
+--source ../include/extract_init_connect_variable_value.inc
+
 # creating data directory, configuration file, etc.
 --let $binsrv_connect_timeout = 20
 --let $binsrv_read_timeout = 60
 --let $binsrv_idle_time = 10
+--let $binsrv_verify_checksum = $extracted_init_connect_variable_value
 --source ../include/set_up_binsrv_environment.inc
 
 --echo

--- a/mtr/binlog_streaming/t/pull_mode.test
+++ b/mtr/binlog_streaming/t/pull_mode.test
@@ -22,6 +22,7 @@ eval $stmt_reset_binary_logs_and_gtids;
 --let $binsrv_connect_timeout = 3
 --let $binsrv_read_timeout = 3
 --let $binsrv_idle_time = 1
+--let $binsrv_verify_checksum = TRUE
 --source ../include/set_up_binsrv_environment.inc
 
 --echo

--- a/src/binsrv/event/format_description_body_impl.cpp
+++ b/src/binsrv/event/format_description_body_impl.cpp
@@ -15,6 +15,7 @@
 
 #include "binsrv/event/format_description_body_impl.hpp"
 
+#include <cassert>
 #include <iterator>
 #include <ostream>
 #include <stdexcept>
@@ -65,6 +66,15 @@ generic_body_impl<code_type::format_description>::generic_body_impl(
     code_type::format_description>::get_readable_checksum_algorithm()
     const noexcept {
   return to_string_view(get_checksum_algorithm());
+}
+
+[[nodiscard]] bool
+generic_body_impl<code_type::format_description>::has_checksum_algorithm()
+    const noexcept {
+  const auto checksum_algorithm{get_checksum_algorithm()};
+  assert(checksum_algorithm == checksum_algorithm_type::off ||
+         checksum_algorithm == checksum_algorithm_type::crc32);
+  return checksum_algorithm != checksum_algorithm_type::off;
 }
 
 std::ostream &

--- a/src/binsrv/event/format_description_body_impl.hpp
+++ b/src/binsrv/event/format_description_body_impl.hpp
@@ -47,6 +47,8 @@ public:
   [[nodiscard]] std::string_view
   get_readable_checksum_algorithm() const noexcept;
 
+  [[nodiscard]] bool has_checksum_algorithm() const noexcept;
+
 private:
   std::uint8_t checksum_algorithm_{};
 };

--- a/src/binsrv/event/reader_context.hpp
+++ b/src/binsrv/event/reader_context.hpp
@@ -20,7 +20,6 @@
 
 #include <cstdint>
 
-#include "binsrv/event/checksum_algorithm_type_fwd.hpp"
 #include "binsrv/event/common_header_fwd.hpp"
 #include "binsrv/event/event_fwd.hpp"
 #include "binsrv/event/protocol_traits.hpp"
@@ -31,15 +30,16 @@ class [[nodiscard]] reader_context {
   friend class event;
 
 public:
-  reader_context(std::uint32_t encoded_server_version,
-                 checksum_algorithm_type checksum_algorithm);
+  reader_context(std::uint32_t encoded_server_version, bool verify_checksum);
 
   [[nodiscard]] std::uint32_t
   get_current_encoded_server_version() const noexcept {
     return encoded_server_version_;
   }
-  [[nodiscard]] checksum_algorithm_type
-  get_current_checksum_algorithm() const noexcept;
+  [[nodiscard]] bool get_current_verify_checksum() const noexcept {
+    return verify_checksum_;
+  }
+
   [[nodiscard]] std::size_t
   get_current_post_header_length(code_type code) const noexcept;
   [[nodiscard]] std::uint32_t get_current_position() const noexcept {
@@ -56,7 +56,7 @@ private:
   };
   state_type state_{state_type::initial};
   std::uint32_t encoded_server_version_;
-  checksum_algorithm_type checksum_algorithm_;
+  bool verify_checksum_;
   post_header_length_container post_header_lengths_{};
   std::uint32_t position_{0U};
 

--- a/src/binsrv/log_severity.hpp
+++ b/src/binsrv/log_severity.hpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <array>
+#include <concepts>
 #include <istream>
 #include <ostream>
 #include <string_view>

--- a/src/easymysql/connection.hpp
+++ b/src/easymysql/connection.hpp
@@ -64,6 +64,7 @@ public:
 
   void switch_to_replication(std::uint32_t server_id,
                              std::string_view file_name, std::uint64_t position,
+                             bool verify_checksum,
                              connection_replication_mode_type blocking_mode);
 
   // returns false on 'connection closed' / 'timeout'

--- a/src/util/crc_helpers.cpp
+++ b/src/util/crc_helpers.cpp
@@ -13,26 +13,24 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-#ifndef EASYMYSQL_REPLICATION_CONFIG_HPP
-#define EASYMYSQL_REPLICATION_CONFIG_HPP
-
-#include "easymysql/replication_config_fwd.hpp" // IWYU pragma: export
+#include "util/crc_helpers.hpp"
 
 #include <cstdint>
+#include <iterator>
 
-#include "util/nv_tuple.hpp"
+#include <zconf.h>
+#include <zlib.h>
 
-namespace easymysql {
+#include "util/byte_span_fwd.hpp"
 
-struct [[nodiscard]] replication_config
-    : util::nv_tuple<
-          // clang-format off
-          util::nv<"server_id", std::uint32_t>,
-          util::nv<"idle_time", std::uint32_t>,
-          util::nv<"verify_checksum", bool>
-          // clang-format on
-          > {};
+namespace util {
 
-} // namespace easymysql
+std::uint32_t calculate_crc32(const_byte_span portion) noexcept {
+  auto crc = crc32_z(0UL, Z_NULL, 0U);
+  return static_cast<std::uint32_t>(
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      crc32_z(crc, reinterpret_cast<const Bytef *>(std::data(portion)),
+              std::size(portion)));
+}
 
-#endif // EASYMYSQL_REPLICATION_CONFIG_HPP
+} // namespace util

--- a/src/util/crc_helpers.hpp
+++ b/src/util/crc_helpers.hpp
@@ -13,26 +13,17 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-#ifndef EASYMYSQL_REPLICATION_CONFIG_HPP
-#define EASYMYSQL_REPLICATION_CONFIG_HPP
-
-#include "easymysql/replication_config_fwd.hpp" // IWYU pragma: export
+#ifndef UTIL_CRC_HELPERS_HPP
+#define UTIL_CRC_HELPERS_HPP
 
 #include <cstdint>
 
-#include "util/nv_tuple.hpp"
+#include "util/byte_span_fwd.hpp"
 
-namespace easymysql {
+namespace util {
 
-struct [[nodiscard]] replication_config
-    : util::nv_tuple<
-          // clang-format off
-          util::nv<"server_id", std::uint32_t>,
-          util::nv<"idle_time", std::uint32_t>,
-          util::nv<"verify_checksum", bool>
-          // clang-format on
-          > {};
+[[nodiscard]] std::uint32_t calculate_crc32(const_byte_span portion) noexcept;
 
-} // namespace easymysql
+} // namespace util
 
-#endif // EASYMYSQL_REPLICATION_CONFIG_HPP
+#endif // UTIL_CRC_HELPERS_HPP


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10006

The 'replication' section of the main JSON configuration file now includes one more boolean 'verify_checksum' parameter which when set to 'true' instructs the utility to perform binary log event checksum verification ('crc32').

The implementation of the 'calculate_crc32()' function is taken from the 'zlib' library which ensures that hardware CRC processor instructions are used when available.

Extended 'easymysql::connection' class: its 'switch_to_replication()' method now takes additional 'verify_checksum' boolean parameter and sets the values of the '@source_binlog_checksum' / '@master_binlog_checksum' session variables to either 'CRC32' or 'NONE' depending on its value.

'binsrv::event::event' class now performs checksum verification in its constructor and throws an exception on mismatch.

'binlog_streaming.binsrv' MTR test case now has 4 combinations:
- with '--binlog-checksum' server option set to 'NONE' or 'CRC32'
- with the utility 'replication.verify_checksum' configuration parameter set to 'false' or 'true'.

'set_up_binsrv_environment.inc' MTR include file now expects one more parameter '$binsrv_verify_checksum' which will be used for 'replication.verify_checksum' during JSON configuration file generation.

Added auxiliary 'extract_init_connect_variable_value.inc' MTR include file that helps to extract the value of the variable set via --init-connect="SET @foo=bar"' command line option. This helps to add "virtual" combinations to MTR test cases.