### PR TITLE
PS-10009 feature: Add support for dns_srv_name in the connection section of the configuration file

### DIFF
--- a/src/binsrv/main_config.cpp
+++ b/src/binsrv/main_config.cpp
@@ -62,6 +62,10 @@ main_config::main_config(std::string_view file_name) {
 
   auto json_value = boost::json::parse(file_content);
   util::nv_tuple_from_json(json_value, impl_);
+
+  validate();
 }
+
+void main_config::validate() const { root().get<"connection">().validate(); }
 
 } // namespace binsrv

--- a/src/binsrv/main_config.hpp
+++ b/src/binsrv/main_config.hpp
@@ -46,6 +46,8 @@ public:
 
 private:
   impl_type impl_;
+
+  void validate() const;
 };
 
 } // namespace binsrv

--- a/src/easymysql/config_common_types.hpp
+++ b/src/easymysql/config_common_types.hpp
@@ -16,12 +16,18 @@
 #ifndef EASYMYSQL_CONFIG_COMMON_TYPES_HPP
 #define EASYMYSQL_CONFIG_COMMON_TYPES_HPP
 
+#include <cstdint>
 #include <optional>
 #include <string>
 
 namespace easymysql {
 
 using optional_string = std::optional<std::string>;
+
+using optional_uint8_t = std::optional<std::uint8_t>;
+using optional_uint16_t = std::optional<std::uint16_t>;
+using optional_uint32_t = std::optional<std::uint32_t>;
+using optional_uint64_t = std::optional<std::uint64_t>;
 
 } // namespace easymysql
 

--- a/src/easymysql/connection_config.hpp
+++ b/src/easymysql/connection_config.hpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <string>
 
+#include "easymysql/config_common_types.hpp"
 #include "easymysql/ssl_config.hpp" // IWYU pragma: export
 #include "easymysql/tls_config.hpp" // IWYU pragma: export
 
@@ -31,8 +32,9 @@ namespace easymysql {
 struct [[nodiscard]] connection_config
     : util::nv_tuple<
           // clang-format off
-          util::nv<"host"           , std::string>,
-          util::nv<"port"           , std::uint16_t>,
+          util::nv<"host"           , optional_string>,
+          util::nv<"port"           , optional_uint16_t>,
+          util::nv<"dns_srv_name"   , optional_string>,
           util::nv<"user"           , std::string>,
           util::nv<"password"       , std::string>,
           util::nv<"connect_timeout", std::uint32_t>,
@@ -46,7 +48,13 @@ struct [[nodiscard]] connection_config
     return !get<"password">().empty();
   }
 
+  [[nodiscard]] bool has_dns_srv_name() const noexcept {
+    return get<"dns_srv_name">().has_value();
+  }
+
   [[nodiscard]] std::string get_connection_string() const;
+
+  void validate() const;
 };
 
 } // namespace easymysql


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10009

Added optional string "dns_srv_name" parameter to the "connection" section of the main JSON configuration file. "host" and "port" parameters in the same section made optional. Added configuration validation method that makes sure that only one of the "dns_srv_name" and ("host", "port") pair is provided.

In the case when "dns_srv_name" is set we now establish connection to the MySQL Server via 'mysql_real_connect_dns_srv()' function instead of 'mysql_real_connect()'.

Extended 'connection_config::get_connection_string()' method to take into account that connection can be established via "dns_srv_name".