### PR TITLE
PS-10010 feature: Implement periodic checkpointing for S3 storage backend (part 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,8 @@ set(source_files
   src/util/command_line_helpers.hpp
   src/util/command_line_helpers.cpp
 
+  src/util/common_optional_types.hpp
+
   src/util/conversion_helpers.hpp
 
   src/util/composite_name_fwd.hpp
@@ -254,8 +256,6 @@ set(source_files
   src/util/redirectable.hpp
 
   # mysql wrapper library files
-  src/easymysql/config_common_types.hpp
-
   src/easymysql/core_error_helpers_private.hpp
   src/easymysql/core_error_helpers_private.cpp
   src/easymysql/core_error.hpp

--- a/README.md
+++ b/README.md
@@ -207,8 +207,9 @@ The Percona Binary Log Server configuration file has the following format.
     "verify_checksum": true
   },
   "storage": {
-    "backend": "file",
-    "uri": "file:///home/user/vault"
+    "backend": "s3",
+    "uri": "https://key_id:secret@192.168.0.100:9000/binsrv-bucket/vault",
+    "fs_buffer_directory": "/tmp/binsrv"
   }
 }
 ```
@@ -261,6 +262,7 @@ Currently we use the following mapping:
   - `file` - local filesystem
   - `s3` - `AWS S3` or `S3`-compatible server (MinIO, etc.)
 - `<storage.uri>` - specifies the location (either local or remote) where the received binary logs should be stored
+- `<storage.fs_buffer_directory>` (optional) - specifies the location on the local filesystem where partially downloaded binlog files should be stored. If not specified, the value of the default OS temporary directory will be used (e.g. '/tmp' on Linux). Currently, this parameter is meaningful only for non-`file` storage backends.
 
 ##### Storage URI format
 
@@ -288,7 +290,7 @@ In case of `AWS S3`, the URIs must have the following format.
 In case of `S3`-compatible service with custom endpoint, the URIs must have the following format.
 `http[s]://[<access_key_id>:<secret_access_key>@]<host>[:<port>]/<bucket_name>/<path>`, where:
 - `<host>` - either a host name or an IP address of an `S3`-compatible server,
-- `<port>` - the portof an `S3`-compatible server to connect to (optional, if omitted, it will be either 80 or 443, depending of the URI scheme: HTTP or HTTPS).
+- `<port>` - the port of an `S3`-compatible server to connect to (optional, if omitted, it will be either 80 or 443, depending of the URI scheme: HTTP or HTTPS).
 Please notice that in this case `<bucket_name>` must be specified as the very first segment of the URI path.
 
 For example:

--- a/mtr/binlog_streaming/include/set_up_binsrv_environment.inc
+++ b/mtr/binlog_streaming/include/set_up_binsrv_environment.inc
@@ -33,6 +33,7 @@ if ($storage_backend == file)
 }
 if ($storage_backend == s3)
 {
+  --let $binsrv_buffer_path = $MYSQL_TMP_DIR/buffer
   --let $binsrv_storage_path = `SELECT CONCAT('/mtr-', UUID())`
   --let $aws_s3_bucket = $MTR_BINSRV_AWS_S3_BUCKET
   if ($MTR_BINSRV_AWS_S3_ENDPOINT != '')
@@ -85,6 +86,10 @@ eval SET @binsrv_config_json = JSON_OBJECT(
      'uri', @storage_uri
   )
 );
+if ($storage_backend == s3)
+{
+  eval SET @binsrv_config_json = JSON_INSERT(@binsrv_config_json, '$.storage.fs_buffer_directory', '$binsrv_buffer_path');
+}
 
 if ($binsrv_ssl_mode != "")
 {
@@ -134,4 +139,8 @@ if ($have_windows) {
 if ($storage_backend == file)
 {
   --mkdir $binsrv_storage_path
+}
+if ($storage_backend == s3)
+{
+  --mkdir $binsrv_buffer_path
 }

--- a/mtr/binlog_streaming/include/tear_down_binsrv_environment.inc
+++ b/mtr/binlog_streaming/include/tear_down_binsrv_environment.inc
@@ -7,6 +7,7 @@ if ($storage_backend == file)
 if ($storage_backend == s3)
 {
   --exec $aws_cli s3 rm s3://$aws_s3_bucket$binsrv_storage_path/ --recursive > /dev/null
+  --force-rmdir $binsrv_buffer_path
 }
 
 --echo

--- a/src/binsrv/filesystem_storage_backend.hpp
+++ b/src/binsrv/filesystem_storage_backend.hpp
@@ -20,9 +20,8 @@
 #include <fstream>
 #include <string_view>
 
-#include <boost/url/url_view_base.hpp>
-
 #include "binsrv/basic_storage_backend.hpp" // IWYU pragma: export
+#include "binsrv/storage_config_fwd.hpp"
 
 namespace binsrv {
 
@@ -33,7 +32,7 @@ public:
 
   static constexpr std::string_view uri_schema{"file"};
 
-  explicit filesystem_storage_backend(const boost::urls::url_view_base &uri);
+  explicit filesystem_storage_backend(const storage_config &config);
 
   [[nodiscard]] const std::filesystem::path &get_root_path() const noexcept {
     return root_path_;

--- a/src/binsrv/s3_storage_backend.hpp
+++ b/src/binsrv/s3_storage_backend.hpp
@@ -26,6 +26,7 @@
 #include <boost/uuid/uuid_generators.hpp>
 
 #include "binsrv/basic_storage_backend.hpp" // IWYU pragma: export
+#include "binsrv/storage_config_fwd.hpp"
 
 namespace binsrv {
 
@@ -35,7 +36,7 @@ public:
 
   static constexpr std::string_view original_uri_schema{"s3"};
 
-  explicit s3_storage_backend(const boost::urls::url_view_base &uri);
+  explicit s3_storage_backend(const storage_config &config);
   s3_storage_backend(const s3_storage_backend &) = delete;
   s3_storage_backend &operator=(const s3_storage_backend &) = delete;
   s3_storage_backend(s3_storage_backend &&) = delete;
@@ -55,6 +56,7 @@ private:
   std::filesystem::path root_path_;
   std::string current_name_;
   boost::uuids::random_generator uuid_generator_;
+  std::filesystem::path tmp_file_directory_;
   std::filesystem::path current_tmp_file_path_;
   std::fstream tmp_fstream_;
 

--- a/src/binsrv/storage_backend_factory.cpp
+++ b/src/binsrv/storage_backend_factory.cpp
@@ -17,9 +17,6 @@
 
 #include <cassert>
 #include <memory>
-#include <stdexcept>
-
-#include <boost/url/parse.hpp>
 
 #include "binsrv/basic_storage_backend_fwd.hpp"
 #include "binsrv/filesystem_storage_backend.hpp"
@@ -27,27 +24,17 @@
 #include "binsrv/storage_backend_type.hpp"
 #include "binsrv/storage_config.hpp"
 
-#include "util/exception_location_helpers.hpp"
-
 namespace binsrv {
 
 basic_storage_backend_ptr
 storage_backend_factory::create(const storage_config &config) {
-  const auto &backend_uri = config.get<"uri">();
-
-  const auto uri_parse_result{boost::urls::parse_absolute_uri(backend_uri)};
-  if (!uri_parse_result) {
-    util::exception_location().raise<std::invalid_argument>(
-        "invalid storage backend URI");
-  }
-
   const auto storage_backend = config.get<"backend">();
 
   switch (storage_backend) {
   case storage_backend_type::file:
-    return std::make_unique<filesystem_storage_backend>(*uri_parse_result);
+    return std::make_unique<filesystem_storage_backend>(config);
   case storage_backend_type::s3:
-    return std::make_unique<s3_storage_backend>(*uri_parse_result);
+    return std::make_unique<s3_storage_backend>(config);
   default:
     assert(false);
   }

--- a/src/binsrv/storage_config.hpp
+++ b/src/binsrv/storage_config.hpp
@@ -22,6 +22,7 @@
 
 #include "binsrv/storage_backend_type_fwd.hpp"
 
+#include "util/common_optional_types.hpp"
 #include "util/nv_tuple.hpp"
 
 namespace binsrv {
@@ -30,7 +31,8 @@ namespace binsrv {
 struct [[nodiscard]] storage_config
     : util::nv_tuple<
           util::nv<"backend", storage_backend_type>,
-          util::nv<"uri", std::string>
+          util::nv<"uri", std::string>,
+          util::nv<"fs_buffer_directory", util::optional_string>
       > {};
 // clang-format on
 

--- a/src/easymysql/connection_config.cpp
+++ b/src/easymysql/connection_config.cpp
@@ -29,13 +29,12 @@ std::string connection_config::get_connection_string() const {
   if (has_dns_srv_name()) {
     const auto &opt_dns_srv_name{get<"dns_srv_name">()};
     res += "[DNS SRV: ";
-    res += (opt_dns_srv_name.has_value() ? opt_dns_srv_name.value()
-                                         : "<unspecified>");
+    res += opt_dns_srv_name.value_or("<unspecified>");
     res += ']';
 
   } else {
     const auto &opt_host{get<"host">()};
-    res += (opt_host.has_value() ? opt_host.value() : "<unspecified host>");
+    res += opt_host.value_or("<unspecified host>");
     res += ':';
     const auto &opt_port{get<"port">()};
     res += (opt_port.has_value() ? std::to_string(opt_port.value())

--- a/src/easymysql/connection_config.hpp
+++ b/src/easymysql/connection_config.hpp
@@ -21,10 +21,10 @@
 #include <cstdint>
 #include <string>
 
-#include "easymysql/config_common_types.hpp"
 #include "easymysql/ssl_config.hpp" // IWYU pragma: export
 #include "easymysql/tls_config.hpp" // IWYU pragma: export
 
+#include "util/common_optional_types.hpp"
 #include "util/nv_tuple.hpp"
 
 namespace easymysql {
@@ -32,9 +32,9 @@ namespace easymysql {
 struct [[nodiscard]] connection_config
     : util::nv_tuple<
           // clang-format off
-          util::nv<"host"           , optional_string>,
-          util::nv<"port"           , optional_uint16_t>,
-          util::nv<"dns_srv_name"   , optional_string>,
+          util::nv<"host"           , util::optional_string>,
+          util::nv<"port"           , util::optional_uint16_t>,
+          util::nv<"dns_srv_name"   , util::optional_string>,
           util::nv<"user"           , std::string>,
           util::nv<"password"       , std::string>,
           util::nv<"connect_timeout", std::uint32_t>,

--- a/src/easymysql/ssl_config.hpp
+++ b/src/easymysql/ssl_config.hpp
@@ -20,9 +20,9 @@
 
 #include <cstdint>
 
-#include "easymysql/config_common_types.hpp"
 #include "easymysql/ssl_mode_type_fwd.hpp"
 
+#include "util/common_optional_types.hpp"
 #include "util/nv_tuple.hpp"
 
 namespace easymysql {
@@ -31,13 +31,13 @@ namespace easymysql {
 struct [[nodiscard]] ssl_config
     : util::nv_tuple<
           util::nv<"mode"   , ssl_mode_type>,
-          util::nv<"ca"     , optional_string>,
-          util::nv<"capath" , optional_string>,
-          util::nv<"crl"    , optional_string>,
-          util::nv<"crlpath", optional_string>,
-          util::nv<"cert"   , optional_string>,
-          util::nv<"key"    , optional_string>,
-          util::nv<"cipher" , optional_string>
+          util::nv<"ca"     , util::optional_string>,
+          util::nv<"capath" , util::optional_string>,
+          util::nv<"crl"    , util::optional_string>,
+          util::nv<"crlpath", util::optional_string>,
+          util::nv<"cert"   , util::optional_string>,
+          util::nv<"key"    , util::optional_string>,
+          util::nv<"cipher" , util::optional_string>
           > {};
 // clang-format on
 

--- a/src/easymysql/tls_config.hpp
+++ b/src/easymysql/tls_config.hpp
@@ -18,8 +18,7 @@
 
 #include "easymysql/tls_config_fwd.hpp" // IWYU pragma: export
 
-#include "easymysql/config_common_types.hpp"
-
+#include "util/common_optional_types.hpp"
 #include "util/nv_tuple.hpp"
 
 namespace easymysql {
@@ -27,8 +26,8 @@ namespace easymysql {
 // clang-format off
 struct [[nodiscard]] tls_config
     : util::nv_tuple<
-          util::nv<"ciphersuites", optional_string>,
-          util::nv<"version"     , optional_string>
+          util::nv<"ciphersuites", util::optional_string>,
+          util::nv<"version"     , util::optional_string>
           > {};
 // clang-format on
 

--- a/src/util/common_optional_types.hpp
+++ b/src/util/common_optional_types.hpp
@@ -13,14 +13,14 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-#ifndef EASYMYSQL_CONFIG_COMMON_TYPES_HPP
-#define EASYMYSQL_CONFIG_COMMON_TYPES_HPP
+#ifndef UTIL_COMMON_OPTIONAL_TYPES_HPP
+#define UTIL_COMMON_OPTIONAL_TYPES_HPP
 
 #include <cstdint>
 #include <optional>
 #include <string>
 
-namespace easymysql {
+namespace util {
 
 using optional_string = std::optional<std::string>;
 
@@ -29,6 +29,6 @@ using optional_uint16_t = std::optional<std::uint16_t>;
 using optional_uint32_t = std::optional<std::uint32_t>;
 using optional_uint64_t = std::optional<std::uint64_t>;
 
-} // namespace easymysql
+} // namespace util
 
-#endif // EASYMYSQL_CONFIG_COMMON_TYPES_HPP
+#endif // UTIL_COMMON_OPTIONAL_TYPES_HPP


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10010

'storage' section of the main configuration file extended with one more optional string 'fs_buffer_directory' configuration parameter that represents where on a local filesystem partially downloaded binary log files should be stored before being uploaded to the storage backend. If not specified, the value of this parameter is considered to be the default OS temporary directory (e.g. '/tmp' on Linux).

More diagnostic storage / storage backend information is now printed into the log file.

MTR test cases adapted to set this new '<storage.fs_buffer_directory>' configuration parameter to '$MYSQL_TMP_DIR/buffer' in case when storage backend is 's3'.

'main_config.json' sample configuration file updated with new '<storage.fs_buffer_directory>' parameter.

Updates 'README.md' with the '<storage.fs_buffer_directory>' parameter description.