### PR TITLE
PS-10010 feature: Implement periodic checkpointing for S3 storage backend (part 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,10 @@ set(source_files
   src/binsrv/operation_mode_type_fwd.hpp
   src/binsrv/operation_mode_type.hpp
 
+  src/binsrv/size_unit_fwd.hpp
+  src/binsrv/size_unit.hpp
+  src/binsrv/size_unit.cpp
+
   src/binsrv/s3_error_helpers_private.hpp
   src/binsrv/s3_error_helpers_private.cpp
   src/binsrv/s3_error.hpp

--- a/main_config.json
+++ b/main_config.json
@@ -33,6 +33,8 @@
   },
   "storage": {
     "backend": "file",
-    "uri": "file:///home/user/vault"
+    "uri": "file:///home/user/vault",
+    "fs_buffer_directory": "/tmp/binsrv",
+    "checkpoint_size": "2M"
   }
 }

--- a/mtr/binlog_streaming/include/set_up_binsrv_environment.inc
+++ b/mtr/binlog_streaming/include/set_up_binsrv_environment.inc
@@ -14,6 +14,7 @@
 #   --let $binsrv_tls_version = TLSv1.2 (optional)
 #   --let $binsrv_idle_time = 10
 #   --let $binsrv_verify_checksum = TRUE | FALSE
+#   --let $binsrv_checkpoint_size = 2M (optional)
 #   --source set_up_binsrv_environment.inc
 
 --echo
@@ -89,6 +90,11 @@ eval SET @binsrv_config_json = JSON_OBJECT(
 if ($storage_backend == s3)
 {
   eval SET @binsrv_config_json = JSON_INSERT(@binsrv_config_json, '$.storage.fs_buffer_directory', '$binsrv_buffer_path');
+}
+
+if ($binsrv_checkpoint_size != "")
+{
+  eval SET @binsrv_config_json = JSON_INSERT(@binsrv_config_json, '$.storage.checkpoint_size', '$binsrv_checkpoint_size');
 }
 
 if ($binsrv_ssl_mode != "")

--- a/mtr/binlog_streaming/r/checkpointing.result
+++ b/mtr/binlog_streaming/r/checkpointing.result
@@ -1,0 +1,26 @@
+*** Resetting replication at the very beginning of the test.
+*** Creating a simple table.
+CREATE TABLE t1(
+id SERIAL,
+val CHAR(64) CHARACTER SET ascii NOT NULL,
+PRIMARY KEY(id)
+) ENGINE=InnoDB;
+*** Filling the table with a large number of records, periodically flushing binary logs.
+*** Dropping the table.
+DROP TABLE t1;
+
+*** Generating a configuration file in JSON format for the Binlog
+*** Server utility.
+
+*** Determining binlog file directory from the server.
+
+*** Creating a temporary directory <BINSRV_STORAGE_PATH> for storing
+*** binlog files downloaded via the Binlog Server utility.
+
+*** Executing the Binlog Server utility to download all binlog data
+
+*** Removing the Binlog Server utility storage directory.
+
+*** Removing the Binlog Server utility log file.
+
+*** Removing the Binlog Server utility configuration file.

--- a/mtr/binlog_streaming/t/checkpointing.test
+++ b/mtr/binlog_streaming/t/checkpointing.test
@@ -1,0 +1,66 @@
+--source ../include/have_binsrv.inc
+
+--source ../include/v80_v84_compatibility_defines.inc
+
+--echo *** Resetting replication at the very beginning of the test.
+--disable_query_log
+eval $stmt_reset_binary_logs_and_gtids;
+--enable_query_log
+
+--echo *** Creating a simple table.
+CREATE TABLE t1(
+  id SERIAL,
+  val CHAR(64) CHARACTER SET ascii NOT NULL,
+  PRIMARY KEY(id)
+) ENGINE=InnoDB;
+
+# This workload generates 4 binlog files, ~5MB each
+--let $number_of_binlog_files = 4
+--let $number_of_transactions_within_binlog_file = 64
+--let $number_of_statements_within_transaction = 512
+
+--echo *** Filling the table with a large number of records, periodically flushing binary logs.
+--disable_query_log
+--let $binlog_idx = 0
+while ($binlog_idx < $number_of_binlog_files)
+{
+  --let $transaction_idx = 0
+  while ($transaction_idx < $number_of_transactions_within_binlog_file)
+  {
+    START TRANSACTION;
+    --let $statement_idx = 0
+    while ($statement_idx < $number_of_statements_within_transaction)
+    {
+      eval INSERT INTO t1(val) VALUES(SHA2(LAST_INSERT_ID(), 256));
+      --inc $statement_idx
+    }
+    COMMIT;
+    --inc $transaction_idx
+  }
+  FLUSH BINARY LOGS;
+  --inc $binlog_idx
+}
+--enable_query_log
+
+--echo *** Dropping the table.
+DROP TABLE t1;
+
+# identifying backend storage type ('file' or 's3')
+--source ../include/identify_storage_backend.inc
+
+# creating data directory, configuration file, etc.
+--let $binsrv_connect_timeout = 20
+--let $binsrv_read_timeout = 60
+--let $binsrv_idle_time = 10
+--let $binsrv_verify_checksum = TRUE
+# enabling checkointing at about 40% of expected single binlog file size, so that checkpointing
+# will happen twice before rotation
+--let $binsrv_checkpoint_size = 2M
+--source ../include/set_up_binsrv_environment.inc
+
+--echo
+--echo *** Executing the Binlog Server utility to download all binlog data
+--exec $BINSRV fetch $binsrv_config_file_path > /dev/null
+
+# cleaning up
+--source ../include/tear_down_binsrv_environment.inc

--- a/src/binsrv/basic_storage_backend.cpp
+++ b/src/binsrv/basic_storage_backend.cpp
@@ -58,6 +58,14 @@ void basic_storage_backend::write_data_to_stream(util::const_byte_span data) {
   do_write_data_to_stream(data);
 }
 
+void basic_storage_backend::flush_stream() {
+  if (!stream_open_) {
+    util::exception_location().raise<std::logic_error>(
+        "cannot flush the stream as it has not been opened");
+  }
+  do_flush_stream();
+}
+
 void basic_storage_backend::close_stream() {
   if (!stream_open_) {
     util::exception_location().raise<std::logic_error>(

--- a/src/binsrv/basic_storage_backend.hpp
+++ b/src/binsrv/basic_storage_backend.hpp
@@ -43,6 +43,7 @@ public:
   void open_stream(std::string_view name,
                    storage_backend_open_stream_mode mode);
   void write_data_to_stream(util::const_byte_span data);
+  void flush_stream();
   void close_stream();
 
   [[nodiscard]] std::string get_description() const;
@@ -58,6 +59,7 @@ private:
   virtual void do_open_stream(std::string_view name,
                               storage_backend_open_stream_mode mode) = 0;
   virtual void do_write_data_to_stream(util::const_byte_span data) = 0;
+  virtual void do_flush_stream() = 0;
   virtual void do_close_stream() = 0;
 
   [[nodiscard]] virtual std::string do_get_description() const = 0;

--- a/src/binsrv/basic_storage_backend_fwd.hpp
+++ b/src/binsrv/basic_storage_backend_fwd.hpp
@@ -45,7 +45,7 @@ struct transparent_string_like_hash {
     return std::hash<std::string>{}(key);
   }
 };
-// the container thatr uses transparent_string_like_hash also needs a
+// the container that uses transparent_string_like_hash also needs a
 // transparent version of KeyEqual template argument (std::equal_to<void>)
 using storage_object_name_container =
     std::unordered_map<std::string, std::uint64_t, transparent_string_like_hash,

--- a/src/binsrv/filesystem_storage_backend.cpp
+++ b/src/binsrv/filesystem_storage_backend.cpp
@@ -113,19 +113,19 @@ filesystem_storage_backend::do_get_object(std::string_view name) {
                            std::ios_base::in | std::ios_base::binary};
   if (!object_ifs.is_open()) {
     util::exception_location().raise<std::runtime_error>(
-        "cannot open undellying object file");
+        "cannot open underlying object file");
   }
   auto file_size = std::filesystem::file_size(object_path);
   if (file_size > max_memory_object_size) {
     util::exception_location().raise<std::out_of_range>(
-        "undellying object file is too large to be loaded in memory");
+        "underlying object file is too large to be loaded in memory");
   }
 
   std::string file_content(file_size, 'x');
   if (!object_ifs.read(std::data(file_content),
                        static_cast<std::streamoff>(file_size))) {
     util::exception_location().raise<std::runtime_error>(
-        "cannot read undellying object file content");
+        "cannot read underlying object file content");
   }
   return file_content;
 }
@@ -139,13 +139,13 @@ void filesystem_storage_backend::do_put_object(std::string_view name,
                                             std::ios_base::trunc};
   if (!object_ofs.is_open()) {
     util::exception_location().raise<std::runtime_error>(
-        "cannot open undellying object file for writing");
+        "cannot open underlying object file for writing");
   }
   const auto content_sv = util::as_string_view(content);
   if (!object_ofs.write(std::data(content_sv),
                         static_cast<std::streamoff>(std::size(content_sv)))) {
     util::exception_location().raise<std::runtime_error>(
-        "cannot write date to undellying object file");
+        "cannot write date to underlying object file");
   }
 }
 
@@ -174,6 +174,10 @@ void filesystem_storage_backend::do_write_data_to_stream(
     util::exception_location().raise<std::runtime_error>(
         "cannot write data to the underlying stream file");
   }
+}
+
+void filesystem_storage_backend::do_flush_stream() {
+  assert(ofs_.is_open());
   if (!ofs_.flush()) {
     util::exception_location().raise<std::runtime_error>(
         "cannot flush the underlying stream file");

--- a/src/binsrv/filesystem_storage_backend.hpp
+++ b/src/binsrv/filesystem_storage_backend.hpp
@@ -51,6 +51,7 @@ private:
   void do_open_stream(std::string_view name,
                       storage_backend_open_stream_mode mode) override;
   void do_write_data_to_stream(util::const_byte_span data) override;
+  void do_flush_stream() override;
   void do_close_stream() override;
 
   [[nodiscard]] std::string do_get_description() const override;

--- a/src/binsrv/main_config.cpp
+++ b/src/binsrv/main_config.cpp
@@ -22,12 +22,14 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 #include <boost/json/parse.hpp>
 #include <boost/json/src.hpp> // IWYU pragma: keep
 
 // Needed for log_severity's operator <<
 #include "binsrv/log_severity.hpp" // IWYU pragma: keep
+#include "binsrv/size_unit_fwd.hpp"
 // Needed for storage_backend_type's operator <<
 #include "binsrv/storage_backend_type.hpp" // IWYU pragma: keep
 
@@ -36,6 +38,22 @@
 
 #include "util/exception_location_helpers.hpp"
 #include "util/nv_tuple_from_json.hpp"
+#include "util/nv_tuple_fwd.hpp"
+
+// As this file is the only place where we call util::nv_tuple_from_json(),
+// which in turns calls tag_invoke() from the boost::json, we give the
+// serialization/unserialization hints for this library here (instead of
+// polluting each individual class definition).
+template <>
+struct util::is_string_convertable<binsrv::size_unit> : std::true_type {};
+template <>
+struct util::is_string_convertable<binsrv::log_severity> : std::true_type {};
+template <>
+struct util::is_string_convertable<binsrv::storage_backend_type>
+    : std::true_type {};
+template <>
+struct util::is_string_convertable<easymysql::ssl_mode_type> : std::true_type {
+};
 
 namespace binsrv {
 

--- a/src/binsrv/s3_storage_backend.hpp
+++ b/src/binsrv/s3_storage_backend.hpp
@@ -76,6 +76,7 @@ private:
   void do_open_stream(std::string_view name,
                       storage_backend_open_stream_mode mode) override;
   void do_write_data_to_stream(util::const_byte_span data) override;
+  void do_flush_stream() override;
   void do_close_stream() override;
 
   [[nodiscard]] std::string do_get_description() const override;
@@ -83,6 +84,7 @@ private:
   [[nodiscard]] std::filesystem::path
   get_object_path(std::string_view name) const;
   [[nodiscard]] std::filesystem::path generate_tmp_file_path();
+  void upload_tmp_stream_internal();
   void close_stream_internal();
 };
 

--- a/src/binsrv/size_unit.cpp
+++ b/src/binsrv/size_unit.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#include "binsrv/size_unit.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <cstddef>
+#include <iterator>
+#include <limits>
+#include <stdexcept>
+#include <string_view>
+#include <system_error>
+
+#include "util/exception_location_helpers.hpp"
+
+namespace binsrv {
+
+size_unit::size_unit(std::string_view value_sv)
+    : base_value_{}, shift_index_{0U} {
+  const char *value_ptr{std::data(value_sv)};
+  if (value_ptr == nullptr) {
+    util::exception_location().raise<std::invalid_argument>(
+        "unable to construct size unit from nullptr");
+  }
+  const char *value_en{std::next(value_ptr, std::ssize(value_sv))};
+  const auto [parse_ptr,
+              parse_error]{std::from_chars(value_ptr, value_en, base_value_)};
+  if (parse_error != std::errc{}) {
+    util::exception_location().raise<std::invalid_argument>(
+        "unable to parse numeric part in the size unit");
+  }
+  if (parse_ptr == value_en) {
+    // no unit prefix specified, leave value as is
+    return;
+  }
+  if (std::next(parse_ptr) != value_en) {
+    util::exception_location().raise<std::invalid_argument>(
+        "unit prefix in the size unit is expected to be a single character");
+  }
+
+  const auto *const shifts_bg{std::cbegin(shifts)};
+  const auto *const shifts_en{std::cend(shifts)};
+
+  // deliberately skipping the very first element
+  const auto *const shifts_it{
+      std::find_if(std::next(shifts_bg), shifts_en,
+                   [symbol = *parse_ptr](const auto &shift_pair) {
+                     return shift_pair.first == symbol;
+                   })};
+  if (shifts_it == shifts_en) {
+    util::exception_location().raise<std::invalid_argument>(
+        "unknown unit prefix in the size unit");
+  }
+
+  if (base_value_ == 0ULL) {
+    // Zero with any multipliyer is still zero, leaving shift_index as zero as
+    // well.
+    return;
+  }
+
+  if (base_value_ > (std::numeric_limits<decltype(base_value_)>::max() >>
+                     shifts_it->second)) {
+    util::exception_location().raise<std::out_of_range>(
+        "the specified size unit cannot be represented in a 64-bit unsigned "
+        "integer");
+  }
+
+  shift_index_ = static_cast<std::size_t>(std::distance(shifts_bg, shifts_it));
+}
+
+} // namespace binsrv

--- a/src/binsrv/size_unit.hpp
+++ b/src/binsrv/size_unit.hpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#ifndef BINSRV_SIZE_UNIT_HPP
+#define BINSRV_SIZE_UNIT_HPP
+
+#include "binsrv/size_unit_fwd.hpp" // IWYU pragma: export
+
+#include <array>
+#include <concepts>
+#include <cstdint>
+#include <istream>
+#include <ostream>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace binsrv {
+
+class [[nodiscard]] size_unit {
+public:
+  size_unit() noexcept : base_value_{0ULL}, shift_index_{0ULL} {}
+  explicit size_unit(std::string_view value_sv);
+
+  [[nodiscard]] std::uint64_t get_value() const noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+    return base_value_ << shifts[shift_index_].second;
+  }
+
+  [[nodiscard]] std::string to_string() const {
+    std::string result{std::to_string(base_value_)};
+    if (shift_index_ != 0U) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+      result += shifts[shift_index_].first;
+    }
+    return result;
+  }
+
+  [[nodiscard]] std::string get_description() const {
+    std::string result{to_string()};
+    if (shift_index_ != 0) {
+      result += " (";
+      result += std::to_string(get_value());
+      result += ')';
+    }
+    return result;
+  }
+
+private:
+  std::uint64_t base_value_;
+  std::size_t shift_index_;
+
+  // clang-format off
+  static constexpr std::array shifts{
+    std::pair{'_',  0ULL},
+    std::pair{'K', 10ULL},
+    std::pair{'M', 20ULL},
+    std::pair{'G', 30ULL},
+    std::pair{'T', 40ULL},
+    std::pair{'P', 50ULL}
+  };
+  // clang-format on
+};
+
+template <typename Char, typename Traits>
+  requires std::same_as<Char, char>
+std::basic_ostream<Char, Traits> &
+operator<<(std::basic_ostream<Char, Traits> &output, const size_unit &unit) {
+  return output << unit.to_string();
+}
+
+template <typename Char, typename Traits>
+  requires std::same_as<Char, char>
+std::basic_istream<Char, Traits> &
+operator>>(std::basic_istream<Char, Traits> &input, size_unit &unit) {
+  std::string unit_str;
+  input >> unit_str;
+  if (!input) {
+    return input;
+  }
+  try {
+    unit = size_unit{unit_str};
+  } catch (const std::exception &) {
+    input.setstate(std::ios_base::failbit);
+  }
+  return input;
+}
+
+} // namespace binsrv
+
+#endif // BINSRV_SIZE_UNIT_HPP

--- a/src/binsrv/size_unit_fwd.hpp
+++ b/src/binsrv/size_unit_fwd.hpp
@@ -13,31 +13,30 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-#ifndef BINSRV_STORAGE_CONFIG_HPP
-#define BINSRV_STORAGE_CONFIG_HPP
+#ifndef BINSRV_SIZE_UNIT_FWD_HPP
+#define BINSRV_SIZE_UNIT_FWD_HPP
 
-#include "binsrv/storage_config_fwd.hpp" // IWYU pragma: export
-
-#include <string>
-
-#include "binsrv/size_unit.hpp"
-#include "binsrv/storage_backend_type_fwd.hpp"
-
-#include "util/common_optional_types.hpp"
-#include "util/nv_tuple.hpp"
+#include <concepts>
+#include <istream>
+#include <optional>
+#include <ostream>
 
 namespace binsrv {
 
-// clang-format off
-struct [[nodiscard]] storage_config
-    : util::nv_tuple<
-          util::nv<"backend", storage_backend_type>,
-          util::nv<"uri", std::string>,
-          util::nv<"fs_buffer_directory", util::optional_string>,
-          util::nv<"checkpoint_size", optional_size_unit>
-      > {};
-// clang-format on
+class size_unit;
+
+using optional_size_unit = std::optional<size_unit>;
+
+template <typename Char, typename Traits>
+  requires std::same_as<Char, char>
+std::basic_ostream<Char, Traits> &
+operator<<(std::basic_ostream<Char, Traits> &output, const size_unit &unit);
+
+template <typename Char, typename Traits>
+  requires std::same_as<Char, char>
+std::basic_istream<Char, Traits> &
+operator>>(std::basic_istream<Char, Traits> &input, size_unit &unit);
 
 } // namespace binsrv
 
-#endif // BINSRV_STORAGE_CONFIG_HPP
+#endif // BINSRV_SIZE_UNIT_FWD_HPP

--- a/src/binsrv/storage.hpp
+++ b/src/binsrv/storage.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "binsrv/basic_storage_backend_fwd.hpp"
+#include "binsrv/storage_config_fwd.hpp"
 
 #include "util/byte_span_fwd.hpp"
 
@@ -34,7 +35,7 @@ public:
   static constexpr std::string_view default_binlog_index_entry_path{"."};
 
   // passing by value as we are going to move from this unique_ptr
-  explicit storage(basic_storage_backend_ptr backend);
+  explicit storage(const storage_config &config);
 
   storage(const storage &) = delete;
   storage &operator=(const storage &) = delete;
@@ -43,6 +44,8 @@ public:
 
   // desctuctor is explicitly defined as default here to complete the rule of 5
   ~storage();
+
+  [[nodiscard]] std::string get_backend_description() const;
 
   [[nodiscard]] bool has_current_binlog_name() const noexcept {
     return !binlog_names_.empty();
@@ -69,6 +72,13 @@ private:
   using binlog_name_container = std::vector<std::string>;
   binlog_name_container binlog_names_;
   std::uint64_t position_{0ULL};
+
+  std::uint64_t checkpoint_size_{0ULL};
+  std::uint64_t last_checkpoint_position_{0ULL};
+
+  [[nodiscard]] bool size_checkpointing_enabled() const noexcept {
+    return checkpoint_size_ != 0;
+  }
 
   void load_binlog_index();
   void validate_binlog_index(const storage_object_name_container &object_names);

--- a/src/util/nv_tuple_from_json.hpp
+++ b/src/util/nv_tuple_from_json.hpp
@@ -105,10 +105,10 @@ T tag_invoke(boost::json::value_to_tag<T> /*unused*/,
       json_value, extraction_ctx)};
 }
 
-// The tag_invoke() overload for enumerations that can be converted from
-// std::strings via boost::lexical_cast (have overloaded operator >>).
-template <typename T>
-  requires std::is_enum_v<T>
+// The tag_invoke() overload for types that can be converted from
+// std::strings via boost::lexical_cast (explicitly marked as convertible
+// via util::string_convertable<...> specialization).
+template <string_convertable T>
 T tag_invoke(boost::json::value_to_tag<T> /*unused*/,
              const boost::json::value &json_value,
              const extraction_context & /*extraction_ctx*/) {

--- a/src/util/nv_tuple_fwd.hpp
+++ b/src/util/nv_tuple_fwd.hpp
@@ -77,6 +77,14 @@ template <typename NVTuple>
 using extract_named_value_tuple_base_t =
     typename extract_named_value_tuple_base<NVTuple>::type;
 
+template <typename T> struct is_string_convertable : std::false_type {};
+
+template <typename T>
+inline constexpr bool is_string_convertable_v = is_string_convertable<T>::value;
+
+template <typename T>
+concept string_convertable = is_string_convertable_v<T>;
+
 } // namespace util
 
 #endif // UTIL_NV_TUPLE_FWD_HPP


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10010

'storage' section of the main configuration file extended with one more optional string 'checkpoint_size' configuration parameter that represents the maximum size of a data portion that is allowed to be stored in the local filesystem buffer ('fs_buffer_directory') without uploading it to permanent storage ('uri'). If the parameter is not specified or is equivalent to 0 bytes, then checkpointing by size should be disabled. The parameter is expected to be a string value containing a series of digits followed by an optional magnitude suffix (“[[:digit:]]+[KMGTP]”).

Added new 'binsrv::size_unit' class that helps with parsing size values (like '64K' or '2M').

Improved the way how we can add custom classes (like 'binsrv::size_unit') into 'util::nv_tuple<>'-based config structures. In particular, for new types that can be converted from strings via 'boost::lexical_cast<>' we can just define a specialization of the 'util::is_string_convertable<>' class template.

Reworked the way how we construct storage backends. Instead of doing this manually in the 'main()' function, it is now done in the 'binsrv::storage' constructor, which now accepts 'binsrv::storage_config' and calls 'binsrv::storage_backend_factory::create()' factory method.

Introduced new pure virtual method 'do_flush()' to the 'binsrv::basic_storage_backend' abstract class. In 'binsrv::s3_storage_backend' it is overloaded with actual S3 object uploading while in 'binsrv::file_storage_backend' it performs 'std::ofstream' flushing.

Added new '$binsrv_checkpoint_size' parameter to the 'set_up_binsrv_environment.inc' MTR include file which if set will be put as '<storage.checkpoint_size>' into generated JSON configuration file.

Added new 'binlog_streaming.checkpointing' MTR test case which generates 4 binlog files (5MB each) and runs Binlog Server utility configured with 2MB size checkpointing.

'main_config.json' sample configuration file updated with new '<storage.checkpoint_size>' parameter.

Updates 'README.md' with the '<storage.checkpoint_size>' parameter description.