### PR TITLE
PS-10010 feature: Implement periodic checkpointing for S3 storage backend (part 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,10 @@ set(source_files
   src/binsrv/storage_config_fwd.hpp
   src/binsrv/storage_config.hpp
 
+  src/binsrv/time_unit_fwd.hpp
+  src/binsrv/time_unit.hpp
+  src/binsrv/time_unit.cpp
+
   # various utility files
   src/util/byte_span_fwd.hpp
   src/util/byte_span.hpp

--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ The Percona Binary Log Server configuration file has the following format.
     "backend": "s3",
     "uri": "https://key_id:secret@192.168.0.100:9000/binsrv-bucket/vault",
     "fs_buffer_directory": "/tmp/binsrv",
-    "checkpoint_size": "128M"
+    "checkpoint_size": "128M",
+    "checkpoint_interval": "30s"
   }
 }
 ```
@@ -264,13 +265,18 @@ Currently we use the following mapping:
   - `s3` - `AWS S3` or `S3`-compatible server (MinIO, etc.)
 - `<storage.uri>` - specifies the location (either local or remote) where the received binary logs should be stored
 - `<storage.fs_buffer_directory>` (optional) - specifies the location on the local filesystem where partially downloaded binlog files should be stored. If not specified, the value of the default OS temporary directory will be used (e.g. '/tmp' on Linux). Currently, this parameter is meaningful only for non-`file` storage backends.
-- `<storage.checkpoint_interval>` (optional) - specifies data portion size after achieving which backend storage should flush its internal buffers and write received binlog data permanently. The value is expected to be a string containing an integer followed by an optional suffix 'K' / 'M' / 'G' / 'T' / 'P', e.g. /\d+\[KMGTP\]?/:
+- `<storage.checkpoint_size>` (optional) - specifies data portion size after receiving which backend storage should flush its internal buffers and write received binlog data permanently. If not set or set to zero, checkpointing by size will be disabled. The value is expected to be a string containing an integer followed by an optional suffix 'K' / 'M' / 'G' / 'T' / 'P', e.g. /\d+\[KMGTP\]?/:
   - 'no suffix' (e.g. "42") means no multiplier, the size will be interpreted in bytes ('42 * 1' bytes)
   - 'K' (e.g. "42K") means '2^10' multiplier ('42 * 1024' bytes)
   - 'M' (e.g. "42M") means '2^20' multiplier ('42 * 1048576' bytes)
   - 'G' (e.g. "42G") means '2^30' multiplier ('42 * 2^20' bytes)
   - 'T' (e.g. "42T") means '2^40' multiplier ('42 * 2^40' bytes)
   - 'P' (e.g. "42P") means '2^50' multiplier ('42 * 2^50' bytes)
+- `<storage.checkpoint_interval>` (optional) - specifies time interval after achieving which backend storage should flush its internal buffers and write received binlog data permanently. If not set or set to zero, checkpointing by time interval will be disabled. The value is expected to be a string containing an integer followed by an optional suffix 's' / 'm' / 'h' / 'd' , e.g. /\d+\[smhd\]?/:
+  - 'no suffix' (e.g. "42")  or 's' (e.g. "42s") means seconds
+  - 'm' (e.g. "42m") means minutes ('42 * 60' seconds)
+  - 'h' (e.g. "42h") means hours ('42 * 60 * 60' seconds)
+  - 'd' (e.g. "42d") means days ('42 * 60 * 60 *24' seconds)
 
 ##### Storage URI format
 
@@ -309,7 +315,7 @@ For example:
 - `https://key_id:secret@192.168.0.100:9000/binsrv-bucket/vault` - `key_id` will be used as `AWS_ACCESS_KEY_ID`, `secret` will be used as `AWS_SECRET_ACCESS_KEY`, `binsrv-bucket` will be the name of the bucket, `/vault` will be the virtual directory, `192.168.0.100:9000` will be the custom endpoint of the `S3`-compatible server, the connection will be established via secure HTTPS protocol.
 
 ##### Checkpointing on S3
-Please note that S3 API does not provide a way to append a portion of data to an existing object. Currently, in our S3 storage backend "append" operations are implemented as complete object overwrites meaning data re-uploads. Practically, if your typical binlog file size is '1G' and you set `<storage.checkpoint_interval>` to '256M', you will upload '256M + 512M + 768M + 1024M = 2560M' (about 2.5 times more then your binlog file size in this example). So, keep balance between the value of this parameter and your tipical binlog size.
+Please note that S3 API does not provide a way to append a portion of data to an existing object. Currently, in our S3 storage backend "append" operations are implemented as complete object overwrites meaning data re-uploads. Practically, if your typical binlog file size is '1G' and you set `<storage.checkpoint_size>` to '256M', you will upload '256M + 512M + 768M + 1024M = 2560M' (about 2.5 times more then your binlog file size in this example). So, keep balance between the value of this parameter and your tipical binlog size. Similar concerns can be rised regarding enabling `<storage.checkpoint_interval>`.
 
 ### Resuming previous operation
 

--- a/main_config.json
+++ b/main_config.json
@@ -35,6 +35,7 @@
     "backend": "file",
     "uri": "file:///home/user/vault",
     "fs_buffer_directory": "/tmp/binsrv",
-    "checkpoint_size": "2M"
+    "checkpoint_size": "2M",
+    "checkpoint_interval": "30s"
   }
 }

--- a/mtr/binlog_streaming/include/set_up_binsrv_environment.inc
+++ b/mtr/binlog_streaming/include/set_up_binsrv_environment.inc
@@ -15,6 +15,7 @@
 #   --let $binsrv_idle_time = 10
 #   --let $binsrv_verify_checksum = TRUE | FALSE
 #   --let $binsrv_checkpoint_size = 2M (optional)
+#   --let $binsrv_checkpoint_interval = 30s (optional)
 #   --source set_up_binsrv_environment.inc
 
 --echo
@@ -95,6 +96,11 @@ if ($storage_backend == s3)
 if ($binsrv_checkpoint_size != "")
 {
   eval SET @binsrv_config_json = JSON_INSERT(@binsrv_config_json, '$.storage.checkpoint_size', '$binsrv_checkpoint_size');
+}
+
+if ($binsrv_checkpoint_interval != "")
+{
+  eval SET @binsrv_config_json = JSON_INSERT(@binsrv_config_json, '$.storage.checkpoint_interval', '$binsrv_checkpoint_interval');
 }
 
 if ($binsrv_ssl_mode != "")

--- a/mtr/binlog_streaming/t/checkpointing.combinations
+++ b/mtr/binlog_streaming/t/checkpointing.combinations
@@ -1,0 +1,8 @@
+[checkpointing_size]
+init-connect = SET @binsrv_checkpointing = 'size'
+
+[checkpointing_interval]
+init-connect = SET @binsrv_checkpointing = 'interval'
+
+[checkpointing_both]
+init-connect = SET @binsrv_checkpointing = 'both'

--- a/mtr/binlog_streaming/t/checkpointing.test
+++ b/mtr/binlog_streaming/t/checkpointing.test
@@ -48,14 +48,33 @@ DROP TABLE t1;
 # identifying backend storage type ('file' or 's3')
 --source ../include/identify_storage_backend.inc
 
+# identifying interval checkpointing mode from the conbination
+--let $extracted_init_connect_variable_name = binsrv_checkpointing
+--source ../include/extract_init_connect_variable_value.inc
+
+
 # creating data directory, configuration file, etc.
 --let $binsrv_connect_timeout = 20
 --let $binsrv_read_timeout = 60
 --let $binsrv_idle_time = 10
 --let $binsrv_verify_checksum = TRUE
-# enabling checkointing at about 40% of expected single binlog file size, so that checkpointing
-# will happen twice before rotation
---let $binsrv_checkpoint_size = 2M
+# Enabling checkointing at about 40% of expected single binlog file size, so that it
+# will happen twice before rotation.
+# Like wise, from the time point of view, make interval pretty low so that
+# at lease a few interval checkpointing events will happen.
+if ($extracted_init_connect_variable_value == 'size')
+{
+  --let $binsrv_checkpoint_size = 2M
+}
+if ($extracted_init_connect_variable_value == 'interval')
+{
+  --let $binsrv_checkpoint_interval = 5s
+}
+if ($extracted_init_connect_variable_value == 'interval')
+{
+  --let $binsrv_checkpoint_size = 2M
+  --let $binsrv_checkpoint_interval = 5s
+}
 --source ../include/set_up_binsrv_environment.inc
 
 --echo

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -46,6 +46,7 @@
 #include "binsrv/storage.hpp"
 // needed for storage_backend_type's operator <<
 #include "binsrv/storage_backend_type.hpp" // IWYU pragma: keep
+#include "binsrv/time_unit.hpp"
 
 #include "binsrv/event/code_type.hpp"
 #include "binsrv/event/event.hpp"
@@ -74,6 +75,10 @@ template <typename T> util::optional_string to_log_string(const T &value) {
 }
 
 util::optional_string to_log_string(const binsrv::size_unit &value) {
+  return value.get_description();
+}
+
+util::optional_string to_log_string(const binsrv::time_unit &value) {
   return value.get_description();
 }
 
@@ -167,6 +172,8 @@ void log_storage_config_info(binsrv::basic_logger &logger,
       "binlog storage backend filesystem buffer directory");
   log_config_param<"checkpoint_size">(
       logger, storage_config, "binlog storage backend checkpointing size");
+  log_config_param<"checkpoint_interval">(
+      logger, storage_config, "binlog storage backend checkpointing interval");
 }
 
 void log_storage_info(binsrv::basic_logger &logger,

--- a/src/binsrv/main_config.cpp
+++ b/src/binsrv/main_config.cpp
@@ -32,6 +32,7 @@
 #include "binsrv/size_unit_fwd.hpp"
 // Needed for storage_backend_type's operator <<
 #include "binsrv/storage_backend_type.hpp" // IWYU pragma: keep
+#include "binsrv/time_unit_fwd.hpp"
 
 // Needed for ssl_mode_type's operator <<
 #include "easymysql/ssl_mode_type.hpp" // IWYU pragma: keep
@@ -46,6 +47,8 @@
 // polluting each individual class definition).
 template <>
 struct util::is_string_convertable<binsrv::size_unit> : std::true_type {};
+template <>
+struct util::is_string_convertable<binsrv::time_unit> : std::true_type {};
 template <>
 struct util::is_string_convertable<binsrv::log_severity> : std::true_type {};
 template <>

--- a/src/binsrv/storage.hpp
+++ b/src/binsrv/storage.hpp
@@ -18,6 +18,7 @@
 
 #include "binsrv/storage_fwd.hpp" // IWYU pragma: export
 
+#include <chrono>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -73,11 +74,19 @@ private:
   binlog_name_container binlog_names_;
   std::uint64_t position_{0ULL};
 
-  std::uint64_t checkpoint_size_{0ULL};
+  std::uint64_t checkpoint_size_bytes_{0ULL};
   std::uint64_t last_checkpoint_position_{0ULL};
 
+  std::chrono::steady_clock::duration checkpoint_interval_seconds_{};
+  std::chrono::steady_clock::time_point last_checkpoint_timestamp_{};
+
   [[nodiscard]] bool size_checkpointing_enabled() const noexcept {
-    return checkpoint_size_ != 0;
+    return checkpoint_size_bytes_ != 0;
+  }
+
+  [[nodiscard]] bool interval_checkpointing_enabled() const noexcept {
+    return checkpoint_interval_seconds_ !=
+           std::chrono::steady_clock::duration{};
   }
 
   void load_binlog_index();

--- a/src/binsrv/storage_config.hpp
+++ b/src/binsrv/storage_config.hpp
@@ -22,6 +22,7 @@
 
 #include "binsrv/size_unit.hpp"
 #include "binsrv/storage_backend_type_fwd.hpp"
+#include "binsrv/time_unit.hpp"
 
 #include "util/common_optional_types.hpp"
 #include "util/nv_tuple.hpp"
@@ -34,7 +35,8 @@ struct [[nodiscard]] storage_config
           util::nv<"backend", storage_backend_type>,
           util::nv<"uri", std::string>,
           util::nv<"fs_buffer_directory", util::optional_string>,
-          util::nv<"checkpoint_size", optional_size_unit>
+          util::nv<"checkpoint_size", optional_size_unit>,
+          util::nv<"checkpoint_interval", optional_time_unit>
       > {};
 // clang-format on
 

--- a/src/binsrv/time_unit.hpp
+++ b/src/binsrv/time_unit.hpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#ifndef BINSRV_TIME_UNIT_HPP
+#define BINSRV_TIME_UNIT_HPP
+
+#include "binsrv/time_unit_fwd.hpp" // IWYU pragma: export
+
+#include <array>
+#include <concepts>
+#include <cstdint>
+#include <istream>
+#include <ostream>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace binsrv {
+
+class [[nodiscard]] time_unit {
+public:
+  time_unit() noexcept : base_value_{0ULL}, multiplier_index_{0ULL} {}
+  explicit time_unit(std::string_view value_sv);
+
+  [[nodiscard]] std::uint64_t get_value() const noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+    return base_value_ * multipliers[multiplier_index_].second;
+  }
+
+  [[nodiscard]] std::string to_string() const {
+    std::string result{std::to_string(base_value_)};
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+    result += multipliers[multiplier_index_].first;
+    return result;
+  }
+
+  [[nodiscard]] std::string get_description() const {
+    std::string result{to_string()};
+    if (multiplier_index_ != 0) {
+      result += " (";
+      result += std::to_string(get_value());
+      result += multipliers.front().first;
+      result += ')';
+    }
+    return result;
+  }
+
+private:
+  std::uint64_t base_value_;
+  std::size_t multiplier_index_;
+
+  // clang-format off
+  static constexpr std::array multipliers{
+    std::pair{'s',  1ULL},
+    std::pair{'m', 60ULL},
+    std::pair{'h', 60ULL * 60ULL},
+    std::pair{'d', 60ULL * 60ULL * 24ULL}
+  };
+  // clang-format on
+};
+
+template <typename Char, typename Traits>
+  requires std::same_as<Char, char>
+std::basic_ostream<Char, Traits> &
+operator<<(std::basic_ostream<Char, Traits> &output, const time_unit &unit) {
+  return output << unit.to_string();
+}
+
+template <typename Char, typename Traits>
+  requires std::same_as<Char, char>
+std::basic_istream<Char, Traits> &
+operator>>(std::basic_istream<Char, Traits> &input, time_unit &unit) {
+  std::string unit_str;
+  input >> unit_str;
+  if (!input) {
+    return input;
+  }
+  try {
+    unit = time_unit{unit_str};
+  } catch (const std::exception &) {
+    input.setstate(std::ios_base::failbit);
+  }
+  return input;
+}
+
+} // namespace binsrv
+
+#endif // BINSRV_TIME_UNIT_HPP

--- a/src/binsrv/time_unit_fwd.hpp
+++ b/src/binsrv/time_unit_fwd.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#ifndef BINSRV_TIME_UNIT_FWD_HPP
+#define BINSRV_TIME_UNIT_FWD_HPP
+
+#include <concepts>
+#include <istream>
+#include <optional>
+#include <ostream>
+
+namespace binsrv {
+
+class time_unit;
+
+using optional_time_unit = std::optional<time_unit>;
+
+template <typename Char, typename Traits>
+  requires std::same_as<Char, char>
+std::basic_ostream<Char, Traits> &
+operator<<(std::basic_ostream<Char, Traits> &output, const time_unit &unit);
+
+template <typename Char, typename Traits>
+  requires std::same_as<Char, char>
+std::basic_istream<Char, Traits> &
+operator>>(std::basic_istream<Char, Traits> &input, time_unit &unit);
+
+} // namespace binsrv
+
+#endif // BINSRV_TIME_UNIT_FWD_HPP


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10010

'storage' section of the main configuration file extended with one more optional string 'checkpoint_interval' configuration parameter that represents the maximum time  interval that data in the local filesystem buffer ('fs_buffer_directory') is allowed to be stored without uploading to permanent storage ('uri'). If the parameter is not specified or is equivalent to 0 seconds, then checkpointing by time interval should be disabled. The parameter is expected to be a string value containing a series of digits followed by an optional unit suffix (“[[:digit:]]+[smhd]?”).

Added new 'binsrv::time_unit' class that helps with parsing time interval values (like '10s' or '3m').

Added new '$binsrv_checkpoint_interval' parameter to the 'set_up_binsrv_environment.inc' MTR include file which if set will be put as '<storage.checkpoint_interval>' into generated JSON configuration file.

'binlog_streaming.checkpointing' MTR test case extended with 3 combinations:
- checkpointing by size
- checkpointing by time interval
- checkpointing by both size and time interval

'main_config.json' sample configuration file updated with new '<storage.checkpoint_interval>' parameter.

Updates 'README.md' with the '<storage.checkpoint_interval>' parameter description.