### PR TITLE
PS-10008 feature: Embed product version into the binary

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -241,6 +241,10 @@ jobs:
       # Run Clang Tidy
       run: run-clang-tidy-19 -header-filter=.* -j=${{steps.cpu-cores.outputs.count}} -use-color -p=${{github.workspace}}/src-build-${{matrix.config.label}}
 
+    - name: Application version
+      working-directory: ${{github.workspace}}/src-build-${{matrix.config.label}}
+      run: ./binlog_server version
+
     - name: MTR tests
       if: matrix.config.run_mtr
       working-directory: /usr/lib/mysql-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,8 @@ set(source_files
   # main application files
   src/app.cpp
 
+  src/app_version.hpp
+
   # binlog event data structure files
   src/binsrv/event/checksum_algorithm_type_fwd.hpp
   src/binsrv/event/checksum_algorithm_type.hpp
@@ -142,10 +144,6 @@ set(source_files
   src/binsrv/event/rotate_post_header_impl_fwd.hpp
   src/binsrv/event/rotate_post_header_impl.hpp
   src/binsrv/event/rotate_post_header_impl.cpp
-
-  src/binsrv/event/server_version_fwd.hpp
-  src/binsrv/event/server_version.hpp
-  src/binsrv/event/server_version.cpp
 
   src/binsrv/event/stop_body_impl_fwd.hpp
   src/binsrv/event/stop_body_impl.hpp
@@ -262,6 +260,10 @@ set(source_files
   src/util/nv_tuple_from_json.hpp
 
   src/util/redirectable.hpp
+
+  src/util/semantic_version_fwd.hpp
+  src/util/semantic_version.hpp
+  src/util/semantic_version.cpp
 
   # mysql wrapper library files
   src/easymysql/core_error_helpers_private.hpp

--- a/src/app_version.hpp
+++ b/src/app_version.hpp
@@ -13,13 +13,11 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-#ifndef BINSRV_EVENT_SERVER_VERSION_FWD_HPP
-#define BINSRV_EVENT_SERVER_VERSION_FWD_HPP
+#ifndef APP_VERSION_HPP
+#define APP_VERSION_HPP
 
-namespace binsrv::event {
+#include "util/semantic_version.hpp"
 
-class server_version;
+static constexpr util::semantic_version app_version{0U, 1U, 0U};
 
-} // namespace binsrv::event
-
-#endif // BINSRV_EVENT_SERVER_VERSION_FWD_HPP
+#endif // APP_VERSION_HPP

--- a/src/binsrv/event/format_description_post_header_impl.cpp
+++ b/src/binsrv/event/format_description_post_header_impl.cpp
@@ -30,11 +30,11 @@
 
 #include "binsrv/event/code_type.hpp"
 #include "binsrv/event/protocol_traits.hpp"
-#include "binsrv/event/server_version.hpp"
 
 #include "util/byte_span.hpp"
 #include "util/byte_span_extractors.hpp"
 #include "util/exception_location_helpers.hpp"
+#include "util/semantic_version.hpp"
 
 namespace binsrv::event {
 
@@ -120,7 +120,7 @@ generic_post_header_impl<code_type::format_description>::get_server_version()
 [[nodiscard]] std::uint32_t generic_post_header_impl<
     code_type::format_description>::get_encoded_server_version()
     const noexcept {
-  return server_version{get_server_version()}.get_encoded();
+  return util::semantic_version{get_server_version()}.get_encoded();
 }
 
 [[nodiscard]] std::string generic_post_header_impl<

--- a/src/binsrv/operation_mode_type.hpp
+++ b/src/binsrv/operation_mode_type.hpp
@@ -32,8 +32,9 @@ namespace binsrv {
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 // clang-format off
 #define BINSRV_OPERATION_MODE_TYPE_X_SEQUENCE() \
-  BINSRV_OPERATION_MODE_TYPE_X_MACRO(fetch),  \
-  BINSRV_OPERATION_MODE_TYPE_X_MACRO(pull )
+  BINSRV_OPERATION_MODE_TYPE_X_MACRO(fetch  ),  \
+  BINSRV_OPERATION_MODE_TYPE_X_MACRO(pull   ),  \
+  BINSRV_OPERATION_MODE_TYPE_X_MACRO(version)
 // clang-format on
 
 #define BINSRV_OPERATION_MODE_TYPE_X_MACRO(X) X

--- a/src/util/semantic_version.cpp
+++ b/src/util/semantic_version.cpp
@@ -13,7 +13,7 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-#include "binsrv/event/server_version.hpp"
+#include "util/semantic_version.hpp"
 
 #include <charconv>
 #include <cstdint>
@@ -25,15 +25,16 @@
 
 #include "util/exception_location_helpers.hpp"
 
-namespace binsrv::event {
+namespace util {
 
-server_version::server_version(std::string_view version_string)
+semantic_version::semantic_version(std::string_view version_string)
     : major_{}, minor_{}, patch_{} {
-  const auto dash_pos{version_string.find('-')};
+  const auto dash_pos{version_string.find(extra_delimiter)};
   if (dash_pos != std::string::npos) {
     version_string.remove_suffix(version_string.size() - dash_pos);
   }
-  auto split_result{std::ranges::views::split(version_string, '.')};
+  auto split_result{
+      std::ranges::views::split(version_string, component_delimiter)};
   auto version_it{std::ranges::begin(split_result)};
   const auto version_en{std::ranges::end(split_result)};
 
@@ -65,4 +66,4 @@ server_version::server_version(std::string_view version_string)
   }
 }
 
-} // namespace binsrv::event
+} // namespace util

--- a/src/util/semantic_version.hpp
+++ b/src/util/semantic_version.hpp
@@ -13,24 +13,28 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-#ifndef BINSRV_EVENT_SERVER_VERSION_HPP
-#define BINSRV_EVENT_SERVER_VERSION_HPP
+#ifndef UTIL_SEMANTIC_VERSION_HPP
+#define UTIL_SEMANTIC_VERSION_HPP
 
-#include "binsrv/event/server_version_fwd.hpp" // IWYU pragma: export
+#include "util/semantic_version_fwd.hpp" // IWYU pragma: export
 
 #include <cstdint>
+#include <string>
 #include <string_view>
 
-namespace binsrv::event {
+namespace util {
 
-class [[nodiscard]] server_version {
+class [[nodiscard]] semantic_version {
 private:
+  static constexpr char component_delimiter{'.'};
+  static constexpr char extra_delimiter{'-'};
+
   static constexpr std::uint32_t minor_multiplier{100U};
   static constexpr std::uint32_t major_multiplier{minor_multiplier *
                                                   minor_multiplier};
 
 public:
-  constexpr explicit server_version(
+  constexpr explicit semantic_version(
       std::uint32_t encoded_server_version) noexcept
       : major_{static_cast<std::uint8_t>(encoded_server_version /
                                          major_multiplier % minor_multiplier)},
@@ -40,10 +44,10 @@ public:
                                          minor_multiplier)} {}
 
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-  constexpr server_version(std::uint8_t major, std::uint8_t minor,
-                           std::uint8_t patch) noexcept
+  constexpr semantic_version(std::uint8_t major, std::uint8_t minor,
+                             std::uint8_t patch) noexcept
       : major_{major}, minor_{minor}, patch_{patch} {}
-  explicit server_version(std::string_view version_string);
+  explicit semantic_version(std::string_view version_string);
 
   [[nodiscard]] constexpr std::uint8_t get_major() const noexcept {
     return major_;
@@ -59,9 +63,19 @@ public:
     return (major_ * major_multiplier) + (minor_ * minor_multiplier) + patch_;
   }
 
+  [[nodiscard]] std::string get_string() const {
+    std::string result{};
+    result += std::to_string(major_);
+    result += component_delimiter;
+    result += std::to_string(minor_);
+    result += component_delimiter;
+    result += std::to_string(patch_);
+    return result;
+  }
+
   [[nodiscard]] friend constexpr auto
-  operator<=>(const server_version &first,
-              const server_version &second) = default;
+  operator<=>(const semantic_version &first,
+              const semantic_version &second) = default;
 
 private:
   std::uint8_t major_;
@@ -69,6 +83,6 @@ private:
   std::uint8_t patch_;
 };
 
-} // namespace binsrv::event
+} // namespace util
 
-#endif // BINSRV_EVENT_SERVER_VERSION_HPP
+#endif // UTIL_SEMANTIC_VERSION_HPP

--- a/src/util/semantic_version_fwd.hpp
+++ b/src/util/semantic_version_fwd.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#ifndef UTIL_SEMANTIC_VERSION_FWD_HPP
+#define UTIL_SEMANTIC_VERSION_FWD_HPP
+
+namespace util {
+
+class semantic_version;
+
+} // namespace util
+
+#endif // UTIL_SEMANTIC_VERSION_FWD_HPP


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10008

Binary Log Server binary extended with embedded application semantic version (currently "0.1.0"). The class that was previously used for parsing MySQL Server versions ('binsrv::events::server_version') generalized for supporting generic semantic versions (<major>.<minor>.<patch>(-<extra>)?) and moved into 'util' namespace. Added 'get_string()' method to this new 'util::semantic_version' class to get string representation (dot-delimited) of the semantic version constructed from individual component (<major>, <minor>, and <patch>).

Added new 'app_version.hpp' header file that declares a constexpr instance 'app_version' of the 'util::semantic_version' class with current application version ("0.1.0"). This object is expected to be used in any place in the code where embedded application version is needed.

Main application now accepts one more 'operation_mode' parameter called 'version'. Running "./binlog_server version" is expected to print embedded program version to STDOUT and terminate the program.

Command line arguments validation logic encapsulated in one place into a new 'check_cmd_args()' function.

The embedded server version is now always printed as one of the very first records to the application log.

GitHub Actions scripts extended with one more action that simply executes the binary in the 'version' operation mode.