### PR TITLE
PS-10245 feature: Implement receiving binlog events in GTID mode (part 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,8 @@ set(source_files
   src/util/byte_span_fwd.hpp
   src/util/byte_span.hpp
   src/util/byte_span_extractors.hpp
+  src/util/byte_span_inserters.hpp
+  src/util/byte_span_packed_int_constants.hpp
 
   src/util/command_line_helpers_fwd.hpp
   src/util/command_line_helpers.hpp

--- a/src/binsrv/event/gtid_log_body.cpp
+++ b/src/binsrv/event/gtid_log_body.cpp
@@ -97,7 +97,7 @@ gtid_log_body::gtid_log_body(util::const_byte_span portion) {
       util::extract_fixed_int_from_byte_span(remainder, commit_group_ticket_);
     }
   }
-  if (std::size(remainder) != 0U) {
+  if (!remainder.empty()) {
     util::exception_location().raise<std::invalid_argument>(
         "extra bytes in the gtid_log event body");
   }

--- a/src/binsrv/event/gtid_tagged_log_body_impl.cpp
+++ b/src/binsrv/event/gtid_tagged_log_body_impl.cpp
@@ -134,7 +134,7 @@ generic_body_impl<code_type::gtid_tagged_log>::generic_body_impl(
     last_seen_field_id = field_id;
   }
 
-  if (std::size(remainder) != 0U) {
+  if (!remainder.empty()) {
     util::exception_location().raise<std::invalid_argument>(
         "extra bytes in the gtid_log event body");
   }

--- a/src/binsrv/gtids/gtid_set.hpp
+++ b/src/binsrv/gtids/gtid_set.hpp
@@ -53,6 +53,10 @@ public:
   ~gtid_set();
 
   [[nodiscard]] bool is_empty() const noexcept { return data_.empty(); }
+  [[nodiscard]] bool contains_tags() const noexcept;
+
+  [[nodiscard]] std::size_t calculate_encoded_size() const noexcept;
+  void encode_to(util::byte_span &destination) const;
 
   [[nodiscard]] bool contains(const gtid &value) const noexcept;
 

--- a/src/binsrv/gtids/tag.hpp
+++ b/src/binsrv/gtids/tag.hpp
@@ -41,6 +41,13 @@ public:
 
   [[nodiscard]] bool is_empty() const noexcept { return data_.empty(); }
 
+  [[nodiscard]] std::size_t get_size() const noexcept {
+    return std::size(data_);
+  }
+
+  [[nodiscard]] std::size_t calculate_encoded_size() const noexcept;
+  void encode_to(util::byte_span &destination) const;
+
 private:
   tag_storage data_{};
 };

--- a/src/binsrv/gtids/uuid.hpp
+++ b/src/binsrv/gtids/uuid.hpp
@@ -25,6 +25,8 @@
 
 #include "binsrv/gtids/common_types.hpp"
 
+#include "util/byte_span_fwd.hpp"
+
 namespace binsrv::gtids {
 
 class uuid {
@@ -38,6 +40,11 @@ public:
   [[nodiscard]] bool is_empty() const noexcept { return data_.is_nil(); }
 
   [[nodiscard]] std::string str() const;
+
+  [[nodiscard]] static std::size_t calculate_encoded_size() noexcept {
+    return uuid_length;
+  }
+  void encode_to(util::byte_span &destination) const;
 
   [[nodiscard]] friend auto operator<=>(const uuid &first,
                                         const uuid &second) noexcept = default;

--- a/src/binsrv/s3_storage_backend.cpp
+++ b/src/binsrv/s3_storage_backend.cpp
@@ -408,7 +408,7 @@ s3_storage_backend::aws_context::list_objects(
         util::exception_location().raise<std::logic_error>(
             "encountered an object with unexpected prefix");
       }
-      key.remove_prefix(prefix_str.size());
+      key.remove_prefix(std::size(prefix_str));
     }
     if (!key.empty()) {
       result.emplace(key, model_object.GetSize());

--- a/src/util/bounded_string_storage.hpp
+++ b/src/util/bounded_string_storage.hpp
@@ -29,7 +29,7 @@ namespace util {
 template <std::size_t N>
 [[nodiscard]] std::string_view
 to_string_view(const bounded_string_storage<N> &storage) noexcept {
-  return util::as_string_view(storage);
+  return as_string_view(storage);
 }
 
 template <std::size_t N>

--- a/src/util/byte_span_inserters.hpp
+++ b/src/util/byte_span_inserters.hpp
@@ -1,0 +1,276 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#ifndef UTIL_BYTE_SPAN_INSERTERS_HPP
+#define UTIL_BYTE_SPAN_INSERTERS_HPP
+
+#include <array>
+#include <bit>
+#include <cassert>
+#include <concepts>
+#include <cstddef>
+#include <cstring>
+#include <limits>
+
+#include <boost/endian/conversion.hpp>
+
+#include "util/byte_span_fwd.hpp"
+#include "util/byte_span_packed_int_constants.hpp"
+
+namespace util {
+
+template <typename T>
+  requires std::unsigned_integral<T> || std::same_as<T, std::byte>
+void insert_fixed_int_to_byte_span(
+    byte_span &remainder, T value,
+    std::size_t bytes_to_insert = sizeof(T)) noexcept {
+  assert(bytes_to_insert != 0U);
+  assert(bytes_to_insert <= sizeof(T));
+  assert(std::size(remainder) >= bytes_to_insert);
+  if constexpr (sizeof(T) != 1U) {
+    // A fixed-length unsigned integer stores its value in a series of
+    // bytes with the least significant byte first.
+    // TODO: in c++23 use std::byteswap()
+    T value_in_network_format{boost::endian::native_to_little(value)};
+    std::memcpy(std::data(remainder), &value_in_network_format,
+                bytes_to_insert);
+  } else {
+    using underlying_type = std::underlying_type_t<std::byte>;
+    *std::data(remainder) =
+        static_cast<std::byte>(static_cast<underlying_type>(value));
+  }
+  remainder = remainder.subspan(bytes_to_insert);
+}
+
+template <typename T>
+  requires std::unsigned_integral<T> || std::same_as<T, std::byte>
+[[nodiscard]] bool insert_fixed_int_to_byte_span_checked(
+    byte_span &remainder, T value,
+    std::size_t bytes_to_insert = sizeof(T)) noexcept {
+  if (bytes_to_insert > std::size(remainder)) {
+    return false;
+  }
+  insert_fixed_int_to_byte_span(remainder, value, bytes_to_insert);
+  return true;
+}
+
+template <typename T>
+  requires std::signed_integral<T> || std::same_as<T, std::byte>
+void insert_fixed_int_to_byte_span(
+    byte_span &remainder, T value,
+    [[maybe_unused]] std::size_t bytes_to_insert = sizeof(T)) noexcept {
+  // signed version of the fixed int inserter currently does not support
+  // partial byte insertion (when bytes_to_insert != sizeof(T)) because
+  // it uses unsigned version underneath
+  assert(bytes_to_insert == sizeof(T));
+  assert(std::size(remainder) >= bytes_to_insert);
+  using unsigned_type = std::make_unsigned_t<T>;
+  const auto unsigned_value{static_cast<unsigned_type>(value)};
+  insert_fixed_int_to_byte_span(remainder, unsigned_value);
+}
+
+template <typename T>
+  requires std::signed_integral<T> || std::same_as<T, std::byte>
+[[nodiscard]] bool insert_fixed_int_to_byte_span_checked(
+    byte_span &remainder, T value,
+    std::size_t bytes_to_insert = sizeof(T)) noexcept {
+  if (bytes_to_insert != sizeof(T) || bytes_to_insert > std::size(remainder)) {
+    return false;
+  }
+  insert_fixed_int_to_byte_span(remainder, value, bytes_to_insert);
+  return true;
+}
+
+template <typename T>
+  requires((std::integral<T> && sizeof(T) == 1U) || std::same_as<T, std::byte>)
+void insert_byte_span_to_byte_span(byte_span &remainder,
+                                   std::span<const T> storage_span) noexcept {
+  assert(std::size(remainder) >= std::size(storage_span));
+  std::memcpy(std::data(remainder), std::data(storage_span),
+              std::size(storage_span));
+
+  remainder = remainder.subspan(std::size(storage_span));
+}
+
+template <typename T>
+  requires((std::integral<T> && sizeof(T) == 1U) || std::same_as<T, std::byte>)
+[[nodiscard]] bool insert_byte_span_to_byte_span_checked(
+    byte_span &remainder, std::span<const T> storage_span) noexcept {
+  if (std::size(storage_span) > std::size(remainder)) {
+    return false;
+  }
+  insert_byte_span_to_byte_span(remainder, storage_span);
+  return true;
+}
+
+template <typename T, std::size_t N>
+  requires((std::integral<T> && sizeof(T) == 1U) || std::same_as<T, std::byte>)
+void insert_byte_array_to_byte_span(byte_span &remainder,
+                                    const std::array<T, N> &storage) noexcept {
+  assert(std::size(remainder) >= N);
+  std::memcpy(std::data(remainder), std::data(storage), N);
+
+  remainder = remainder.subspan(N);
+}
+
+template <typename T, std::size_t N>
+  requires((std::integral<T> && sizeof(T) == 1U) || std::same_as<T, std::byte>)
+[[nodiscard]] bool insert_byte_array_to_byte_span_checked(
+    byte_span &remainder, const std::array<T, N> &storage) noexcept {
+  if (N > std::size(remainder)) {
+    return false;
+  }
+  insert_byte_array_to_byte_span(remainder, storage);
+  return true;
+}
+
+template <typename T>
+  requires(std::unsigned_integral<T> && sizeof(T) == sizeof(std::uint64_t))
+[[nodiscard]] std::size_t calculate_packed_int_size(T value) noexcept {
+  // https://github.com/mysql/mysql-server/blob/mysql-8.0.43/mysys/pack.cc#L161
+  // https://github.com/mysql/mysql-server/blob/mysql-8.4.6/mysys/pack.cc#L161
+  if (value < packed_int_single_boundary) {
+    return 1U;
+  }
+  if (value < packed_int_double_boundary) {
+    return packed_int_double_size + 1U;
+  }
+  if (value < packed_int_triple_boundary) {
+    return packed_int_triple_size + 1U;
+  }
+  return packed_int_octuple_size + 1U;
+}
+
+template <typename T>
+  requires(std::unsigned_integral<T> && sizeof(T) == sizeof(std::uint64_t))
+[[nodiscard]] bool insert_packed_int_to_byte_span_checked(byte_span &remainder,
+                                                          T value) noexcept {
+  // https://github.com/mysql/mysql-server/blob/mysql-8.0.43/mysys/pack.cc#L129
+  // https://github.com/mysql/mysql-server/blob/mysql-8.4.6/mysys/pack.cc#L129
+
+  if (value < packed_int_single_boundary) {
+    if (std::size(remainder) < 1U) {
+      return false;
+    }
+    insert_fixed_int_to_byte_span(remainder, value, 1);
+  }
+  /* 251 is reserved for NULL */
+  if (value < packed_int_double_boundary) {
+    if (std::size(remainder) < 1U + packed_int_double_size) {
+      return false;
+    }
+    insert_fixed_int_to_byte_span(remainder, packed_int_double_marker);
+    insert_fixed_int_to_byte_span(remainder, value, packed_int_double_size);
+  }
+  if (value < packed_int_triple_boundary) {
+    if (std::size(remainder) < 1U + packed_int_triple_size) {
+      return false;
+    }
+    insert_fixed_int_to_byte_span(remainder, packed_int_triple_marker);
+    insert_fixed_int_to_byte_span(remainder, value, packed_int_triple_size);
+  } else {
+    if (std::size(remainder) < 1U + packed_int_octuple_size) {
+      return false;
+    }
+    insert_fixed_int_to_byte_span(remainder, packed_int_octuple_marker);
+    insert_fixed_int_to_byte_span(remainder, value, packed_int_octuple_size);
+  }
+
+  return true;
+}
+
+namespace detail {
+
+template <typename T>
+  requires(std::signed_integral<T>)
+[[nodiscard]] auto get_signed_representation_as_unsigned(T value) noexcept {
+  using unsigned_type = std::make_unsigned_t<T>;
+  // sign_mask is 0 if data >= 0 and ~0 if data < 0
+  const auto sign_mask{value < static_cast<T>(0)
+                           ? std::numeric_limits<unsigned_type>::max()
+                           : static_cast<unsigned_type>(0U)};
+  auto result{static_cast<unsigned_type>(value)};
+  result ^= sign_mask;
+  // insert sign bit as the least significant bit
+  result <<= 1U;
+  result |=
+      static_cast<unsigned_type>(sign_mask & static_cast<unsigned_type>(1U));
+  return result;
+}
+
+} // namespace detail
+
+template <typename T>
+  requires(std::unsigned_integral<T>)
+[[nodiscard]] std::size_t calculate_varlen_int_size(T value) noexcept {
+  // https://github.com/mysql/mysql-server/blob/mysql-8.4.6/libs/mysql/serialization/variable_length_integers.h#L49
+  static constexpr std::size_t magic_factor{575U};
+  static constexpr std::size_t magic_shift{12U};
+
+  const auto bits_in_value{static_cast<std::size_t>(std::bit_width(value))};
+  return ((bits_in_value * magic_factor) >> magic_shift) + 1U;
+}
+
+template <typename T>
+  requires(std::signed_integral<T>)
+[[nodiscard]] std::size_t calculate_varlen_int_size(T value) noexcept {
+  return calculate_varlen_int_size(
+      detail::get_signed_representation_as_unsigned(value));
+}
+
+template <typename T>
+  requires(std::unsigned_integral<T>)
+[[nodiscard]] bool insert_varlen_int_to_byte_span_checked(byte_span &remainder,
+                                                          T value) noexcept {
+  // https://github.com/mysql/mysql-server/blob/mysql-8.4.6/libs/mysql/serialization/variable_length_integers.h#L89
+  const auto num_bytes{calculate_varlen_int_size(value)};
+
+  if (std::size(remainder) < num_bytes) {
+    return false;
+  }
+
+  std::uint64_t value_cpy{value};
+  // creating a mask with "<num_bytes> - 1" ones in lower digits,
+  // for instance '0000 0011' for <num_bytes> == 3 or
+  // '0000 0000' for <num_bytes> == 1
+  const std::uint8_t first_byte{static_cast<std::uint8_t>(
+      ((1ULL << (num_bytes - 1U)) - 1ULL) | (value_cpy << num_bytes))};
+  insert_fixed_int_to_byte_span(remainder, first_byte);
+
+  if (num_bytes == 1U) {
+    return true;
+  }
+
+  // If num_bytes < 8, shift right by 8 - num_bytes.
+  // If num_bytes == 8 or num_bytes == 9, no shift is needed.
+  if (num_bytes < sizeof(value_cpy)) {
+    value_cpy >>= (sizeof(value_cpy) - num_bytes);
+  }
+  insert_fixed_int_to_byte_span(remainder, value_cpy, num_bytes - 1U);
+
+  return true;
+}
+
+template <typename T>
+  requires(std::signed_integral<T>)
+[[nodiscard]] bool insert_varlen_int_to_byte_span_checked(byte_span &remainder,
+                                                          T value) noexcept {
+  return insert_varlen_int_to_byte_span_checked(
+      remainder, detail::get_signed_representation_as_unsigned(value));
+}
+
+} // namespace util
+
+#endif // UTIL_BYTE_SPAN_INSERTERS_HPP

--- a/src/util/byte_span_packed_int_constants.hpp
+++ b/src/util/byte_span_packed_int_constants.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#ifndef UTIL_BYTE_SPAN_PACKED_INT_CONSTANTS_HPP
+#define UTIL_BYTE_SPAN_PACKED_INT_CONSTANTS_HPP
+
+#include <cstddef>
+
+namespace util {
+
+inline constexpr std::uint64_t packed_int_single_boundary{251ULL};
+inline constexpr std::uint64_t packed_int_double_boundary{1ULL << 16U};
+inline constexpr std::uint64_t packed_int_triple_boundary{1ULL << 24U};
+
+inline constexpr unsigned char packed_int_max_marker{251U};
+inline constexpr unsigned char packed_int_double_marker{252U};
+inline constexpr unsigned char packed_int_triple_marker{253U};
+inline constexpr unsigned char packed_int_octuple_marker{254U};
+inline constexpr unsigned char packed_int_forbidden_marker{255U};
+
+inline constexpr std::size_t packed_int_double_size{2U};
+inline constexpr std::size_t packed_int_triple_size{3U};
+inline constexpr std::size_t packed_int_octuple_size{8U};
+
+} // namespace util
+
+#endif // UTIL_BYTE_SPAN_PACKED_INT_CONSTANTS_HPP

--- a/src/util/command_line_helpers.cpp
+++ b/src/util/command_line_helpers.cpp
@@ -20,7 +20,7 @@
 
 namespace util {
 
-std::string extract_executable_name(util::command_line_arg_view cmd_args) {
+std::string extract_executable_name(command_line_arg_view cmd_args) {
   std::string res;
   if (!cmd_args.empty()) {
     const std::filesystem::path executable_path{cmd_args[0U]};
@@ -34,7 +34,7 @@ std::string extract_executable_name(util::command_line_arg_view cmd_args) {
 }
 
 std::string
-get_readable_command_line_arguments(util::command_line_arg_view cmd_args) {
+get_readable_command_line_arguments(command_line_arg_view cmd_args) {
   std::string res;
   if (cmd_args.empty()) {
     return res;

--- a/src/util/command_line_helpers.hpp
+++ b/src/util/command_line_helpers.hpp
@@ -31,10 +31,10 @@ inline command_line_arg_view to_command_line_agg_view(
 }
 
 [[nodiscard]] std::string
-extract_executable_name(util::command_line_arg_view cmd_args);
+extract_executable_name(command_line_arg_view cmd_args);
 
 [[nodiscard]] std::string
-get_readable_command_line_arguments(util::command_line_arg_view cmd_args);
+get_readable_command_line_arguments(command_line_arg_view cmd_args);
 
 } // namespace util
 

--- a/src/util/nv_tuple_from_json.hpp
+++ b/src/util/nv_tuple_from_json.hpp
@@ -127,7 +127,7 @@ void nv_tuple_from_json(const boost::json::value &json_value,
     obj =
         boost::json::value_to<nv_tuple<NVPack...>>(json_value, extraction_ctx);
   } catch (const std::exception &ex) {
-    util::exception_location().raise<std::invalid_argument>(
+    exception_location().raise<std::invalid_argument>(
         "unable to extract \"" + extraction_ctx.to_string() + "\"");
   }
 }

--- a/src/util/nv_tuple_to_json.hpp
+++ b/src/util/nv_tuple_to_json.hpp
@@ -68,7 +68,7 @@ void nv_tuple_to_json(boost::json::value &json_value,
     const detail::insertion_context insertion_ctx{};
     json_value = boost::json::value_from(obj, insertion_ctx);
   } catch (const std::exception &ex) {
-    util::exception_location().raise<std::invalid_argument>(
+    exception_location().raise<std::invalid_argument>(
         "unable to insert into JSON object");
   }
 }

--- a/src/util/semantic_version.cpp
+++ b/src/util/semantic_version.cpp
@@ -31,7 +31,7 @@ semantic_version::semantic_version(std::string_view version_string)
     : major_{}, minor_{}, patch_{} {
   const auto dash_pos{version_string.find(extra_delimiter)};
   if (dash_pos != std::string::npos) {
-    version_string.remove_suffix(version_string.size() - dash_pos);
+    version_string.remove_suffix(std::size(version_string) - dash_pos);
   }
   auto split_result{
       std::ranges::views::split(version_string, component_delimiter)};
@@ -41,7 +41,7 @@ semantic_version::semantic_version(std::string_view version_string)
   const auto component_extractor{
       [version_en](auto &cuttent_it, const std::string &name) -> std::uint8_t {
         if (cuttent_it == version_en) {
-          util::exception_location().raise<std::invalid_argument>(
+          exception_location().raise<std::invalid_argument>(
               "server_version does not have the \"" + name + "\" component");
         }
         std::uint8_t result{};
@@ -50,7 +50,7 @@ semantic_version::semantic_version(std::string_view version_string)
         const auto [conversion_ptr, conversion_ec]{
             std::from_chars(component_it, component_en, result)};
         if (conversion_ec != std::errc{} || conversion_ptr != component_en) {
-          util::exception_location().raise<std::invalid_argument>(
+          exception_location().raise<std::invalid_argument>(
               "server_version \"" + name +
               "\" component is not a numeric value");
         }
@@ -61,7 +61,7 @@ semantic_version::semantic_version(std::string_view version_string)
   minor_ = component_extractor(version_it, "minor");
   patch_ = component_extractor(version_it, "patch");
   if (version_it != version_en) {
-    util::exception_location().raise<std::invalid_argument>(
+    exception_location().raise<std::invalid_argument>(
         "server_version has more than 3 components");
   }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,14 @@
 
 find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 
+set(byte_span_encoding_source_files
+  ${PROJECT_SOURCE_DIR}/src/util/byte_span_fwd.hpp
+  ${PROJECT_SOURCE_DIR}/src/util/byte_span.hpp
+  ${PROJECT_SOURCE_DIR}/src/util/byte_span_extractors.hpp
+  ${PROJECT_SOURCE_DIR}/src/util/byte_span_inserters.hpp
+  ${PROJECT_SOURCE_DIR}/src/util/byte_span_packed_int_constants.hpp
+)
+
 set(uuid_source_files
   ${PROJECT_SOURCE_DIR}/src/binsrv/gtids/uuid_fwd.hpp
   ${PROJECT_SOURCE_DIR}/src/binsrv/gtids/uuid.hpp
@@ -38,6 +46,19 @@ set(gtid_set_source_files
   ${PROJECT_SOURCE_DIR}/src/binsrv/gtids/gtid_set.hpp
   ${PROJECT_SOURCE_DIR}/src/binsrv/gtids/gtid_set.cpp
 )
+
+add_executable(byte_span_encoding_test byte_span_encoding_test.cpp ${byte_span_encoding_source_files})
+target_include_directories(byte_span_encoding_test PRIVATE "${PROJECT_SOURCE_DIR}/src")
+target_link_libraries(byte_span_encoding_test
+  PRIVATE
+    binlog_server_compiler_flags
+    Boost::unit_test_framework
+)
+set_target_properties(byte_span_encoding_test PROPERTIES
+  CXX_STANDARD_REQUIRED YES
+  CXX_EXTENSIONS NO
+)
+
 
 add_executable(uuid_test uuid_test.cpp ${uuid_source_files})
 target_include_directories(uuid_test PRIVATE "${PROJECT_SOURCE_DIR}/src")
@@ -87,6 +108,7 @@ set_target_properties(gtid_set_test PROPERTIES
   CXX_EXTENSIONS NO
 )
 
+add_test(NAME byte_span_encoding_test COMMAND byte_span_encoding_test)
 add_test(NAME uuid_test COMMAND uuid_test)
 add_test(NAME tag_test COMMAND tag_test)
 add_test(NAME gtid_test COMMAND gtid_test)

--- a/tests/byte_span_encoding_test.cpp
+++ b/tests/byte_span_encoding_test.cpp
@@ -1,0 +1,194 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <numeric>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+#define BOOST_TEST_MODULE TagTests
+// this include is needed as it provides the 'main()' function
+// NOLINTNEXTLINE(misc-include-cleaner)
+#include <boost/test/unit_test.hpp>
+
+#include <boost/test/unit_test_log.hpp>
+#include <boost/test/unit_test_suite.hpp>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <boost/mpl/list.hpp>
+
+#include "util/byte_span_extractors.hpp"
+#include "util/byte_span_fwd.hpp"
+#include "util/byte_span_inserters.hpp"
+
+struct mixin_fixture {
+  static constexpr std::size_t bits_in_byte{
+      std::numeric_limits<std::uint8_t>::digits};
+  // varlen int uses 1 byte for each 7 bits
+  static constexpr std::size_t bit_group_size{bits_in_byte - 1U};
+
+  // the number of 7-bit groups in the given type
+  template <typename ValueType>
+  static constexpr std::size_t number_of_iterations =
+      sizeof(ValueType) * bits_in_byte / bit_group_size;
+
+  // an auxiliary method that performs varlen int encoding / decoding of the
+  // provided value and compares the values
+  template <typename ValueType> static void check_roundtrip(ValueType value) {
+    const auto calculated_encoded_size{util::calculate_varlen_int_size(value)};
+    using encoding_buffer_type =
+        std::array<std::byte, sizeof(std::uint64_t) + 1U>;
+
+    encoding_buffer_type buffer;
+    util::byte_span encoding_portion{buffer};
+    BOOST_CHECK(
+        util::insert_varlen_int_to_byte_span_checked(encoding_portion, value));
+
+    const auto actual_encoded_size{std::size(buffer) -
+                                   std::size(encoding_portion)};
+
+    BOOST_CHECK_EQUAL(actual_encoded_size, calculated_encoded_size);
+
+    util::const_byte_span decoding_portion{buffer};
+    ValueType restored_value;
+    BOOST_CHECK(util::extract_varlen_int_from_byte_span_checked(
+        decoding_portion, restored_value));
+
+    const auto actual_decoded_size{std::size(buffer) -
+                                   std::size(decoding_portion)};
+    BOOST_CHECK_EQUAL(actual_decoded_size, calculated_encoded_size);
+
+    BOOST_CHECK_EQUAL(restored_value, value);
+  }
+
+  template <typename ValueType>
+  static std::pair<ValueType, ValueType>
+  calculate_group_min_max_for_iteration(std::size_t iteration) {
+    ValueType group_min;
+    ValueType group_max;
+    if constexpr (std::is_unsigned_v<ValueType>) {
+      // at the very first iteration the min value is always 0
+      group_min = static_cast<ValueType>(1ULL << (bit_group_size * iteration));
+      if (iteration == number_of_iterations<ValueType>) {
+        // for the last iteration the max value is the max value for the given
+        // type - 1
+        group_max = std::numeric_limits<ValueType>::max();
+      } else {
+        group_max =
+            static_cast<ValueType>(1ULL << (bit_group_size * (iteration + 1U)));
+      }
+      --group_max;
+    } else {
+      // at the very first iteration the min value is always 0
+      if (iteration == 0U) {
+        group_min = static_cast<ValueType>(1LL);
+      } else {
+        group_min =
+            static_cast<ValueType>(1ULL << (bit_group_size * iteration - 1U));
+      }
+
+      if (iteration == number_of_iterations<ValueType>) {
+        group_max = std::numeric_limits<ValueType>::max();
+      } else {
+        group_max = static_cast<ValueType>(
+            1ULL << (bit_group_size * (iteration + 1U) - 1U));
+      }
+      --group_max;
+    }
+    return {group_min, group_max};
+  }
+
+  template <typename ValueType>
+  using stream_type_t = std::conditional_t<std::is_signed_v<ValueType>,
+                                           std::int64_t, std::uint64_t>;
+
+  template <typename ValueType>
+  static void print_and_check_single(ValueType value) {
+    BOOST_TEST_MESSAGE("  Value "
+                       << static_cast<stream_type_t<ValueType>>(value));
+    check_roundtrip(value);
+  }
+
+  template <typename ValueType> static void print_and_check(ValueType value) {
+    print_and_check_single(value);
+    if constexpr (std::is_signed_v<ValueType>) {
+      const auto negated_value{static_cast<ValueType>(-value)};
+      print_and_check_single(negated_value);
+    }
+  }
+};
+
+using varlen_int_encoding_types =
+    boost::mpl::list<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t,
+                     std::int8_t, std::int16_t, std::int32_t, std::int64_t>;
+
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(VarlenIntEncoding, ValueType,
+                                 varlen_int_encoding_types, mixin_fixture) {
+  using stream_type = stream_type_t<ValueType>;
+
+  const ValueType delta{16ULL};
+
+  // each iteration represents a new 7-bit gtoup that adds one more byte to the
+  // encoding deliberately adding one more iteration for the last (shorter than
+  // 7-bit) group
+  for (std::size_t iteration{0U}; iteration <= number_of_iterations<ValueType>;
+       ++iteration) {
+    // calculating min and max values of the group
+    auto [group_min, group_max]{
+        calculate_group_min_max_for_iteration<ValueType>(iteration)};
+    // calculating the midpoint
+    const ValueType group_midpoint{std::midpoint(group_min, group_max)};
+    BOOST_TEST_MESSAGE("Iteration "
+                       << iteration << ", min "
+                       << static_cast<stream_type>(group_min) << ", midpoint "
+                       << static_cast<stream_type>(group_midpoint) << ", max "
+                       << static_cast<stream_type>(group_max));
+
+    // checking values in the [group_min; group_min + delta] range
+    for (ValueType current_value{group_min};
+         current_value <= static_cast<ValueType>(group_min + delta);
+         ++current_value) {
+      print_and_check(current_value);
+    }
+
+    // checking values in the [group_midpoint - delta; group_midpoint + delta]
+    // range
+    for (ValueType current_value{
+             static_cast<ValueType>(group_midpoint - delta)};
+         current_value <= static_cast<ValueType>(group_midpoint + delta);
+         ++current_value) {
+      print_and_check(current_value);
+    }
+
+    // checking values in the [group_max - delta; group_max] range
+    for (ValueType current_value{static_cast<ValueType>(group_max - delta)};
+         current_value <= group_max; ++current_value) {
+      print_and_check(current_value);
+    }
+  }
+  // special values are checked separately here
+  BOOST_TEST_MESSAGE("Special iteration ");
+  print_and_check_single(ValueType{});
+  print_and_check(std::numeric_limits<ValueType>::max());
+  if constexpr (std::is_signed_v<ValueType>) {
+    print_and_check_single(std::numeric_limits<ValueType>::min());
+  }
+}


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10245

Implemented encoding functions for GTID sets ('binsrv::gtids::gtid_set') that can be used to prepare GTID set payloads passed to the 'gtid_set_arg' when calling 'mysql_binlog_open()'.

Similarly to "util/byte_span_extractors.hpp" added new "util/byte_span_inserters.hpp" header that includes helper functions for encoding various primitives (fixed signed / unsigned integers, varlen signed / unsigned integers, packed signed / unsigned integers, byte arrays and spans).

Added new 'byte_span_encoding_test' unit test that checks varlen conversions for both signed and unsigned integers of different sizes.

'gtid_set_test' unit test extended with encoding-decoding (roundtrip) checks for untagged, tagged, and mixed GTID sets.