### PR TITLE
PS-10245 feature: Implement receiving binlog events in GTID mode (part 2)

### DIFF
--- a/src/binsrv/storage.hpp
+++ b/src/binsrv/storage.hpp
@@ -27,6 +27,8 @@
 #include "binsrv/replication_mode_type_fwd.hpp"
 #include "binsrv/storage_config_fwd.hpp"
 
+#include "binsrv/gtids/gtid_set.hpp"
+
 #include "util/byte_span_fwd.hpp"
 
 namespace binsrv {
@@ -65,6 +67,10 @@ public:
     return position_;
   }
 
+  [[nodiscard]] const gtids::gtid_set &get_gtids() const noexcept {
+    return gtids_;
+  }
+
   [[nodiscard]] static bool
   check_binlog_name(std::string_view binlog_name) noexcept;
 
@@ -80,6 +86,8 @@ private:
   using binlog_name_container = std::vector<std::string>;
   binlog_name_container binlog_names_;
   std::uint64_t position_{0ULL};
+
+  gtids::gtid_set gtids_{};
 
   std::uint64_t checkpoint_size_bytes_{0ULL};
   std::uint64_t last_checkpoint_position_{0ULL};

--- a/src/easymysql/connection.hpp
+++ b/src/easymysql/connection.hpp
@@ -64,10 +64,18 @@ public:
     return static_cast<bool>(rpl_impl_);
   }
 
-  void switch_to_replication(std::uint32_t server_id,
-                             std::string_view file_name, std::uint64_t position,
-                             bool verify_checksum, bool gtid_mode,
-                             connection_replication_mode_type blocking_mode);
+  void switch_to_position_replication(
+      std::uint32_t server_id, std::string_view file_name,
+      std::uint64_t position, bool verify_checksum,
+      connection_replication_mode_type blocking_mode);
+  // a simplified version for starting from the very beginning
+  void switch_to_position_replication(
+      std::uint32_t server_id, bool verify_checksum,
+      connection_replication_mode_type blocking_mode);
+
+  void switch_to_gtid_replication(
+      std::uint32_t server_id, util::const_byte_span encoded_gtid_set,
+      bool verify_checksum, connection_replication_mode_type blocking_mode);
 
   // returns false on 'connection closed' / 'timeout'
   // returns true and sets 'portion' to en empty span on EOF (last event read)
@@ -76,6 +84,8 @@ public:
   [[nodiscard]] bool fetch_binlog_event(util::const_byte_span &portion);
 
 private:
+  void set_binlog_checksum(bool verify_checksum);
+
   void process_ssl_config(const ssl_config &config);
   void process_tls_config(const tls_config &config);
   void process_connection_config(const connection_config &config);


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10245

Refactored 'easymysql::connection::switch_to_replication()' method. We now have 3 different methods:
- one 'switch_to_gtid_replication()' for GTID mode
- two 'switch_to_position_replication()' for position-based mode (one for starting from the very beginning and another one when binlog name / position are known).

In the main application we now print more info in 'log_replication_info()' depending on the mode (GTID or position-mased).