### PR TITLE
PS-10281 postfix: Implement logic for search_by_gtid_set mode

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -255,9 +255,11 @@ set_target_properties(event_test PROPERTIES
   CXX_EXTENSIONS NO
 )
 
-add_test(NAME byte_span_encoding_test COMMAND byte_span_encoding_test)
-add_test(NAME uuid_test COMMAND uuid_test)
-add_test(NAME tag_test COMMAND tag_test)
-add_test(NAME gtid_test COMMAND gtid_test)
-add_test(NAME gtid_set_test COMMAND gtid_set_test)
-add_test(NAME event_test COMMAND event_test)
+
+set(test_run_options --no_color_output)
+add_test(NAME byte_span_encoding_test COMMAND byte_span_encoding_test ${test_run_options})
+add_test(NAME uuid_test COMMAND uuid_test ${test_run_options})
+add_test(NAME tag_test COMMAND tag_test ${test_run_options})
+add_test(NAME gtid_test COMMAND gtid_test ${test_run_options})
+add_test(NAME gtid_set_test COMMAND gtid_set_test ${test_run_options})
+add_test(NAME event_test COMMAND event_test ${test_run_options})

--- a/tests/gtid_set_test.cpp
+++ b/tests/gtid_set_test.cpp
@@ -721,3 +721,33 @@ BOOST_AUTO_TEST_CASE(GtidSetWhitespaces) {
       boost::lexical_cast<binsrv::gtids::gtid_set>(gtids_str)};
   BOOST_CHECK_EQUAL(gtids, restored_gtids);
 }
+
+BOOST_AUTO_TEST_CASE(GtidSetSimulateSearchByGTIDSet) {
+  constexpr std::string_view first_random_uuid_sv{
+      "ae6896b1-2e94-11f1-af82-76efd046f53d"};
+  constexpr std::string_view second_random_uuid_sv{
+      "bcd66d18-2e94-11f1-b929-76efd046f53d"};
+
+  const std::string first_binlog_file_added_gtids_str{
+      std::string{first_random_uuid_sv} + ":1-4, " +
+      std::string{second_random_uuid_sv} + ":1-1103"};
+  const binsrv::gtids::gtid_set first_binlog_file_added_gtids{
+      first_binlog_file_added_gtids_str};
+  BOOST_CHECK(first_binlog_file_added_gtids.str() ==
+              first_binlog_file_added_gtids_str);
+
+  const binsrv::gtids::gtid lookup_gtid{
+      binsrv::gtids::uuid{second_random_uuid_sv}, 1103ULL};
+
+  BOOST_CHECK(first_binlog_file_added_gtids.contains(lookup_gtid));
+
+  const binsrv::gtids::gtid_set lookup_gtids{lookup_gtid};
+  BOOST_CHECK(
+      binsrv::gtids::intersects(first_binlog_file_added_gtids, lookup_gtids));
+  BOOST_CHECK(
+      binsrv::gtids::intersects(lookup_gtids, first_binlog_file_added_gtids));
+
+  binsrv::gtids::gtid_set remaining_gtids{lookup_gtids};
+  remaining_gtids.subtract(first_binlog_file_added_gtids);
+  BOOST_CHECK(remaining_gtids.is_empty());
+}


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10281

'gtid_set_test' (BOOST_TEST_MODULE GtidSetTests) unit test extended with new test case 'GtidSetSimulateSearchByGTIDSet' which simulates the logic of 'search_by_gtid_set' main application operation mode.

Updated unit tests 'CMakeLists.txt' file . We now run unit tests with '--no_color_output' command line option which helps with better integration with VS Code.