### PR TITLE
PS-10911 fix: unexpected binlog position in artificial rotate event

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ set(source_files
 
   src/binsrv/storage_config_fwd.hpp
   src/binsrv/storage_config.hpp
+  src/binsrv/storage_config.cpp
 
   src/binsrv/storage_metadata_fwd.hpp
   src/binsrv/storage_metadata.hpp

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -249,7 +249,9 @@ void log_storage_config_info(binsrv::basic_logger &logger,
 
   log_config_param<"backend">(logger, storage_config,
                               "binlog storage backend type");
-  // not printing "uri" here deliberately to avoid credentials leaking
+  logger.log(binsrv::log_severity::info,
+             "binlog storage backend URI (masked): " +
+                 storage_config.get_masked_uri());
   log_config_param<"fs_buffer_directory">(
       logger, storage_config,
       "binlog storage backend filesystem buffer directory");
@@ -420,14 +422,17 @@ void process_artificial_rotate_event(
         storage.get_current_binlog_name()) {
       // in addition, in position-based replication mode we also need to check
       // the position
-      const binsrv::events::generic_post_header<
-          binsrv::events::code_type::rotate>
-          current_rotate_post_header{current_event_v.get_post_header_raw()};
+      if (storage.get_replication_mode() ==
+          binsrv::replication_mode_type::position) {
+        const binsrv::events::generic_post_header<
+            binsrv::events::code_type::rotate>
+            current_rotate_post_header{current_event_v.get_post_header_raw()};
 
-      if (current_rotate_post_header.get_position_raw() !=
-          storage.get_current_position()) {
-        util::exception_location().raise<std::logic_error>(
-            "unexpected binlog position in artificial rotate event");
+        if (current_rotate_post_header.get_position_raw() !=
+            storage.get_current_position()) {
+          util::exception_location().raise<std::logic_error>(
+              "unexpected binlog position in artificial rotate event");
+        }
       }
 
       binlog_opening_needed = false;

--- a/src/binsrv/basic_logger.cpp
+++ b/src/binsrv/basic_logger.cpp
@@ -15,6 +15,7 @@
 
 #include "binsrv/basic_logger.hpp"
 
+#include <cstddef>
 #include <string>
 #include <string_view>
 
@@ -31,17 +32,22 @@ basic_logger::basic_logger(log_severity min_level) noexcept
 
 void basic_logger::log(log_severity level, std::string_view message) {
   if (level >= min_level_) {
-    static constexpr auto timestamp_length{
+    // the length of the longest log severity label
+    // ('trace' / 'debug' / 'info' / 'warning' / 'error' / 'fatal')
+    static constexpr std::size_t padded_label_length{7U};
+    static constexpr std::size_t timestamp_length{
         std::size("YYYY-MM-DDTHH:MM:SS.fffffffff") - 1U};
     const auto timestamp = boost::posix_time::microsec_clock::universal_time();
-    ;
     const auto level_label = to_string_view(level);
+    const std::string label_padding(
+        padded_label_length - std::size(level_label), ' ');
     std::string buf;
-    buf.reserve(1 + timestamp_length + 1 + 1 + 1 + std::size(level_label) + 1 +
-                1 + std::size(message));
+    buf.reserve(1U + timestamp_length + 1U + 1U + 1U + padded_label_length +
+                1U + 1U + std::size(message));
     buf += '[';
     buf += boost::posix_time::to_iso_extended_string(timestamp);
     buf += "] [";
+    buf += label_padding;
     buf += level_label;
     buf += "] ";
     buf += message;

--- a/src/binsrv/storage_config.cpp
+++ b/src/binsrv/storage_config.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2023-2024 Percona and/or its affiliates.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#include "binsrv/storage_config.hpp"
+
+#include <string>
+
+#include <boost/url/url.hpp>
+
+namespace binsrv {
+
+[[nodiscard]] std::string storage_config::get_masked_uri() const {
+  boost::urls::url masked_uri{get<"uri">()};
+  if (masked_uri.has_userinfo()) {
+    masked_uri.set_userinfo("***:***");
+  }
+  return masked_uri.c_str();
+}
+
+} // namespace binsrv

--- a/src/binsrv/storage_config.hpp
+++ b/src/binsrv/storage_config.hpp
@@ -37,7 +37,9 @@ struct [[nodiscard]] storage_config
           util::nv<"fs_buffer_directory", util::optional_string>,
           util::nv<"checkpoint_size", optional_size_unit>,
           util::nv<"checkpoint_interval", optional_time_unit>
-      > {};
+      > {
+  [[nodiscard]] std::string get_masked_uri() const;
+};
 // clang-format on
 
 } // namespace binsrv


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10911

Fixed problem with not being able to properly process ROTATE (artificial) events after reconnection in GTID-based replication mode (in the 'pull' operation mode). Original 'position' field checking in the artificial ROTATE event post-header makes sense only for the position-based replication mode.

Extended 'log_storage_config_info()' - we now also print the masked storage URI (the one with hidden 'user' / 'password' components) to the log.

Minor improvements in the log message formatting - now all 'trace' / 'debug' / 'info' / 'warning' / 'error' / 'fatal' log severity labels are padded to the same width.