### PR TITLE
PS-10321 postfix: binlog-server fails to read the new events after upgrading server from 8.0 to 8.4

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -303,6 +303,7 @@ jobs:
         BINSRV=${{github.workspace}}/src-build-${{matrix.config.label}}/binlog_server ./mtr \
           --vardir=${{runner.temp}}/mtrvardir80 \
           --force --max-test-fail=0 --retry=0 --nounit-tests --big-test --repeat=2 --parallel=${{steps.cpu-cores.outputs.count}} \
+          --testcase-timeout=30 --suite-timeout=60 --shutdown-timeout=600 \
           --suite=binlog_streaming ${{matrix.config.mtr_options}}
 
     - name: MTR 8.4 tests
@@ -312,6 +313,7 @@ jobs:
         BINSRV=${{github.workspace}}/src-build-${{matrix.config.label}}/binlog_server ./mtr \
           --vardir=${{runner.temp}}/mtrvardir84 \
           --force --max-test-fail=0 --retry=0 --nounit-tests --big-test --repeat=2 --parallel=${{steps.cpu-cores.outputs.count}} \
+          --testcase-timeout=30 --suite-timeout=60 --shutdown-timeout=600 \
           --suite=binlog_streaming ${{matrix.config.mtr_options}}
 
     - name: CTest

--- a/mtr/binlog_streaming/t/data_directory_8_0_to_8_4_upgrade.test
+++ b/mtr/binlog_streaming/t/data_directory_8_0_to_8_4_upgrade.test
@@ -42,7 +42,7 @@ if ($lts_series != v84)
 --echo *** Running 8.4 binaries on a 8.0 data directory
 --let $MYSQLD_LOG = $MYSQLTEST_VARDIR/log/upgrade.log
 --let $do_not_echo_parameters = 1
---let $restart_parameters = restart: --datadir=$CUSTOM_MYSQLD_DATADIR --log-error=$MYSQLD_LOG
+--let $restart_parameters = restart: --datadir=$CUSTOM_MYSQLD_DATADIR --log-error=$MYSQLD_LOG --binlog_expire_logs_auto_purge=OFF
 --source include/start_mysqld.inc
 
 --echo


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10321

Fixed 'binlog_streaming.data_directory_8_0_to_8_4_upgrade' MTR test case that started to fail after 30 days since it was created. The problem turned out to be connected with enabled automatic purging of binary log files (set to 30 days) that started to happen upon MySQL Server restart during 8.0 -> 8.4 data directory upgrade. Fixed by adding the
"--log-error=$MYSQLD_LOG --binlog_expire_logs_auto_purge=OFF" command line option to the restart command.