### PR TITLE
Merge tag 'pbs-0.2.3' into main postfix

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -320,6 +320,7 @@ jobs:
         BINSRV=${{github.workspace}}/src-build-${{matrix.config.label}}/binlog_server ./mtr \
           --vardir=${{runner.temp}}/mtrvardir80 \
           --force --max-test-fail=0 --retry=0 --nounit-tests --big-test --parallel=${{steps.cpu-cores.outputs.count}} \
+          --testcase-timeout=30 --suite-timeout=60 --shutdown-timeout=600 \
           --suite=binlog_streaming ${{matrix.config.mtr_options}}
 
     - name: MTR 8.4 tests
@@ -329,6 +330,7 @@ jobs:
         BINSRV=${{github.workspace}}/src-build-${{matrix.config.label}}/binlog_server ./mtr \
           --vardir=${{runner.temp}}/mtrvardir84 \
           --force --max-test-fail=0 --retry=0 --nounit-tests --big-test --parallel=${{steps.cpu-cores.outputs.count}} \
+          --testcase-timeout=30 --suite-timeout=60 --shutdown-timeout=600 \
           --suite=binlog_streaming ${{matrix.config.mtr_options}}
 
     - name: CTest


### PR DESCRIPTION
Added timeouts to MTR invocations inside GitHub Actions scripts missed during the main merge. This fix is supposed to increase MTR stability on low-end virtual machines like default GitHub Actions workers.