### PR TITLE
PS-11205 fix: When fs_buffer_directory is not set the temporary buffer directory is created in the current binary path rather than in /tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ If this section is present, then the utility will not split binlog events the sa
   - `file` - local filesystem
   - `s3` - `AWS S3` or `S3`-compatible server (MinIO, etc.)
 - `<storage.uri>` - specifies the location (either local or remote) where the received binary logs should be stored
-- `<storage.fs_buffer_directory>` (optional) - specifies the location on the local filesystem where partially downloaded binlog files should be stored. If not specified, the value of the default OS temporary directory will be used (e.g. '/tmp' on Linux). Currently, this parameter is meaningful only for non-`file` storage backends.
+- `<storage.fs_buffer_directory>` (optional) - specifies the location on the local filesystem where partially downloaded binlog files should be stored. If not specified, a unique subdirectory under the default OS temporary directory (e.g. `/tmp` on Linux) will be created and used. This auto-created directory is automatically removed when the server exits. If you set this parameter explicitly, the directory is never deleted automatically. This parameter is meaningful only for non-`file` storage backends.
 - `<storage.checkpoint_size>` (optional) - specifies data portion size after receiving which backend storage should flush its internal buffers and write received binlog data permanently. If not set or set to zero, checkpointing by size will be disabled. The value is expected to be a string containing an integer followed by an optional suffix 'K' / 'M' / 'G' / 'T' / 'P', e.g. /\d+\[KMGTP\]?/:
   - 'no suffix' (e.g. "42") means no multiplier, the size will be interpreted in bytes ('42 * 1' bytes)
   - 'K' (e.g. "42K") means '2^10' multiplier ('42 * 1024' bytes)

--- a/src/binsrv/s3_storage_backend.cpp
+++ b/src/binsrv/s3_storage_backend.cpp
@@ -490,7 +490,15 @@ s3_storage_backend::s3_storage_backend(const storage_config &config)
   if (opt_fs_buffer_directory.has_value()) {
     tmp_file_directory_ = *opt_fs_buffer_directory;
   } else {
-    tmp_file_directory_ = boost::uuids::to_string(uuid_generator_());
+    std::error_code fs_error{};
+    const auto tmp_directory{std::filesystem::temp_directory_path(fs_error)};
+    if (fs_error) {
+      util::exception_location().raise<std::invalid_argument>(
+          "unable to resolve default OS temporary directory");
+    }
+    tmp_file_directory_ =
+        tmp_directory / boost::uuids::to_string(uuid_generator_());
+    owns_tmp_file_directory_ = true;
   }
 
   const auto tmp_file_directory_status{
@@ -560,12 +568,15 @@ s3_storage_backend::s3_storage_backend(const storage_config &config)
 }
 
 s3_storage_backend::~s3_storage_backend() {
-  if (!tmp_fstream_.is_open()) {
-    return;
-  }
   // bugprone-empty-catch should not be that strict in destructors
   try {
-    close_stream_internal();
+    if (tmp_fstream_.is_open()) {
+      close_stream_internal();
+    }
+    if (owns_tmp_file_directory_) {
+      std::error_code remove_ec;
+      std::filesystem::remove_all(tmp_file_directory_, remove_ec);
+    }
   } catch (...) { // NOLINT(bugprone-empty-catch)
   }
 }

--- a/src/binsrv/s3_storage_backend.hpp
+++ b/src/binsrv/s3_storage_backend.hpp
@@ -57,6 +57,7 @@ private:
   std::string current_name_;
   boost::uuids::random_generator uuid_generator_;
   std::filesystem::path tmp_file_directory_;
+  bool owns_tmp_file_directory_{false};
   std::filesystem::path current_tmp_file_path_;
   std::fstream tmp_fstream_;
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-11205

* Default buffer directory for S3 storage backend is now a unique subdirectory under the OS temp directory (e.g. /tmp on Linux) if '<storage.fs_buffer_directory>' configuration parameter is not set.
* Auto-created temp directory is removed on storage backend destruction; user-provided directories are never deleted.
* Updated README to document new behavior.