### PR TITLE
PS-11136 postfix: non-GTID transactions cause one storage flush per transaction, bypassing size/interval checkpointing

### DIFF
--- a/mtr/binlog_streaming/t/binlog_flush.test
+++ b/mtr/binlog_streaming/t/binlog_flush.test
@@ -80,7 +80,9 @@ if ($storage_backend == file)
 }
 if ($storage_backend == s3)
 {
-  --exec $aws_cli s3api head-object --bucket $MTR_BINSRV_AWS_S3_BUCKET --key $binsrv_storage_path/$binlog_name --query ContentLength --output text > $size_file 2>/dev/null || echo 0 > $size_file
+  # removing leading '/' from the $binsrv_storage_path
+  --let $relative_binsrv_storage_path = `SELECT SUBSTRING('$binsrv_storage_path', 2)`
+  --exec $aws_cli s3api head-object --bucket $MTR_BINSRV_AWS_S3_BUCKET --key $relative_binsrv_storage_path/$binlog_name --query ContentLength --output text > $size_file 2>/dev/null || echo 0 > $size_file
 }
 --let $read_from_file = $size_file
 --source include/read_file_to_var.inc


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-11136

Fixed problem with the 'binlog_streaming.binlog_flush' MTR test case which used to pass absolute path instead of a relative one to AWS CLI 's3api head-object' invocation.