### PR TITLE
PBS-27 fix: binlog_server list command fails with ERROR if executed while fetch/pull is in progress

### DIFF
--- a/src/binsrv/filesystem_storage_backend.cpp
+++ b/src/binsrv/filesystem_storage_backend.cpp
@@ -16,10 +16,12 @@
 #include "binsrv/filesystem_storage_backend.hpp"
 
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <ios>
+#include <iosfwd>
 #include <iterator>
 #include <stdexcept>
 #include <string>
@@ -114,6 +116,11 @@ filesystem_storage_backend::do_list_objects() {
           "filesystem storage directory contains an entry that is not a "
           "regular file");
     }
+    if (dir_entry.path().extension() == tmp_object_suffix) {
+      // skip temporary files used by the atomic-overwrite implementation of
+      // 'do_put_object'
+      continue;
+    }
     // TODO: check permissions here
     result.emplace(dir_entry.path().filename().string(), dir_entry.file_size());
   }
@@ -132,7 +139,18 @@ filesystem_storage_backend::do_get_object(std::string_view name) {
     util::exception_location().raise<std::runtime_error>(
         "cannot open underlying object file");
   }
-  auto file_size = std::filesystem::file_size(object_path);
+  if (!object_ifs.seekg(0, std::ios_base::end)) {
+    util::exception_location().raise<std::runtime_error>(
+        "cannot seek underlying object file to the end");
+  }
+  const std::streampos end_pos{object_ifs.tellg()};
+  const auto end_offset{static_cast<std::streamoff>(end_pos)};
+  if (!object_ifs.seekg(0, std::ios_base::beg)) {
+    util::exception_location().raise<std::runtime_error>(
+        "cannot seek underlying object file to the beginning");
+  }
+
+  const auto file_size{static_cast<std::size_t>(end_offset)};
   if (file_size > max_memory_object_size) {
     util::exception_location().raise<std::out_of_range>(
         "underlying object file is too large to be loaded in memory");

--- a/src/binsrv/storage.cpp
+++ b/src/binsrv/storage.cpp
@@ -96,6 +96,13 @@ storage::storage(const storage_config &config,
 
   const auto binlog_index_it{storage_objects.find(default_binlog_index_name)};
   if (binlog_index_it == std::cend(storage_objects)) {
+    // as binlog index file is created after the very first binlog data file
+    // and its metadata file are created, the concurrent query-only operation
+    // may intrude exactly between these two steps, so for query-only operations
+    // we should not consider the absence of binlog index file as an error
+    if (construction_mode == storage_construction_mode_type::querying_only) {
+      return;
+    }
     util::exception_location().raise<std::logic_error>(
         "storage is not empty but does not contain binlog index");
   }
@@ -538,6 +545,12 @@ void storage::load_binlog_index() {
 
 void storage::validate_binlog_index(
     const storage_object_name_container &object_names) const {
+  // in the querying_only mode we allow discrepancies between the binlog index
+  // and the actual objects in the storage
+  if (construction_mode_ == storage_construction_mode_type::querying_only) {
+    return;
+  }
+
   for (auto const &record : binlog_records_) {
     if (!object_names.contains(record.name.str())) {
       util::exception_location().raise<std::logic_error>(
@@ -658,28 +671,51 @@ void storage::load_and_validate_binlog_metadata_set(
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     const storage_object_name_container &object_names,
     const storage_object_name_container &object_metadata_names) {
-  for (auto &record : binlog_records_) {
-    const auto binlog_metadata_name{generate_binlog_metadata_name(record.name)};
-    if (!object_metadata_names.contains(binlog_metadata_name)) {
-      util::exception_location().raise<std::logic_error>(
-          "missing metadata for a binlog listed in the binlog index");
+  auto record_it{std::begin(binlog_records_)};
+  while (record_it != std::end(binlog_records_)) {
+    storage::binlog_record loaded_binlog_metadata{};
+    try {
+      const auto binlog_metadata_name{
+          generate_binlog_metadata_name(record_it->name)};
+      if (!object_metadata_names.contains(binlog_metadata_name)) {
+        util::exception_location().raise<std::logic_error>(
+            "missing metadata for a binlog listed in the binlog index");
+      }
+      loaded_binlog_metadata = load_binlog_metadata(record_it->name);
+    } catch (const std::exception &) {
+      if (construction_mode_ == storage_construction_mode_type::querying_only) {
+        // in the querying_only mode we just skip invalid metadata and the
+        // corresponding binlog file - this allows to query an otherwise
+        // unusable storage and retrieve information about valid binlog files
+        // from it, which can be useful for debugging / forensics purposes
+        record_it = binlog_records_.erase(record_it);
+        continue;
+      }
+      throw;
     }
-    auto loaded_binlog_metadata{load_binlog_metadata(record.name)};
     validate_binlog_metadata(loaded_binlog_metadata);
-    // validating that the size stored in the metadata matches the actual size
-    if (loaded_binlog_metadata.size != object_names.at(record.name.str())) {
-      util::exception_location().raise<std::logic_error>(
-          "size from the binlog metadata does not match the actual binlog "
-          "size");
+    // validating binlog size from the metadata only makes sense if we are not
+    // in the querying_only mode
+    if (construction_mode_ != storage_construction_mode_type::querying_only) {
+      // validating that the size stored in the metadata matches the actual size
+      if (loaded_binlog_metadata.size !=
+          object_names.at(record_it->name.str())) {
+        util::exception_location().raise<std::logic_error>(
+            "size from the binlog metadata does not match the actual binlog "
+            "size");
+      }
     }
-    record = std::move(loaded_binlog_metadata);
+    *record_it = std::move(loaded_binlog_metadata);
+    ++record_it;
   }
   // after this loop position_ and gtids_ should store the values from the last
   // binlog file metadata
 
-  if (std::size(object_metadata_names) != std::size(binlog_records_)) {
-    util::exception_location().raise<std::logic_error>(
-        "found metadata for a non-existing binlog");
+  if (construction_mode_ != storage_construction_mode_type::querying_only) {
+    if (std::size(object_metadata_names) != std::size(binlog_records_)) {
+      util::exception_location().raise<std::logic_error>(
+          "found metadata for a non-existing binlog");
+    }
   }
 
   // if we are in GTID replication mode, then we can consider GTIDs from the


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PBS-27

Relaxed integrity validation rules when 'binsrv::storage' is created for 'query_only' operations. Because we allow to run PBS in 'list' / 'search_by_timestamp' / 'search_by_gtid_set' modes concurrently with another process running in 'fetch' / 'pull' mode, there is a chance that query operations will intercept the state when the 'pulling' / 'fetching' process has already updated binlog data file but hasn't updated its corresponding binlog metadata file. With original strict validation rules, these query-only operations used to occasionally return an error and required to make several attempts to get the result.

In addition, reworked the way how we calculate file size for the 'filesystem_storage_backend. Instead of using 'std::filesystem::file_size()' we now use "seek to the end" approach, which behaves much better when we concurrently update file content via a chain of renames.