### PR TITLE
PBS-18 fix: Fix unstable binlog_streaming.binlog_flush MTR test case

### DIFF
--- a/mtr/binlog_streaming/r/binlog_flush.result
+++ b/mtr/binlog_streaming/r/binlog_flush.result
@@ -16,9 +16,10 @@ FLUSH BINARY LOGS;
 *** binlog files downloaded via the Binlog Server utility.
 include/read_file_to_var.inc
 
-*** Waiting for the source-side Binlog Dump thread to report that all
-*** currently available events have been streamed to the Binlog Server
-*** utility.
+*** Waiting until Binlog Server log confirms that it processed an
+*** the ANONYMOUS_GTID_LOG event with sequence_number which is equal
+*** to the number of inserts we executed.
+include/wait_for_pattern_in_file.inc [sequence_number: 20]
 
 *** Capturing storage object size before checkpoint, rotate, timeout, or graceful shutdown.
 include/read_file_to_var.inc

--- a/mtr/binlog_streaming/t/binlog_flush.combinations
+++ b/mtr/binlog_streaming/t/binlog_flush.combinations
@@ -1,7 +1,0 @@
-[gtid_on]
-enforce-gtid-consistency = ON
-gtid-mode = ON
-
-[gtid_off]
-enforce-gtid-consistency = OFF
-gtid-mode = OFF

--- a/mtr/binlog_streaming/t/binlog_flush.test
+++ b/mtr/binlog_streaming/t/binlog_flush.test
@@ -23,7 +23,8 @@ FLUSH BINARY LOGS;
 
 --disable_query_log
 --let $transaction_idx = 0
-while ($transaction_idx < 20)
+--let $number_of_inserts = 20
+while ($transaction_idx < $number_of_inserts)
 {
   INSERT INTO t1 VALUES(DEFAULT);
   --inc $transaction_idx
@@ -56,20 +57,17 @@ EOF
 --let $binsrv_pid = $result
 
 --echo
---echo *** Waiting for the source-side Binlog Dump thread to report that all
---echo *** currently available events have been streamed to the Binlog Server
---echo *** utility.
-# We deliberately avoid waiting for PBS to log "entering
-# idle mode for" because that pattern fires only after the MySQL
-# read timeout, and the read-timeout path itself flushes the event
-# buffer (see receive_binlog_events()) - which would invalidate the
-# "storage stayed empty before any flush trigger" invariant this
-# test asserts.
-let $wait_condition = SELECT COUNT(*) FROM performance_schema.processlist
-                      WHERE COMMAND = 'Binlog Dump'
-                      AND STATE LIKE '%sent all binlog to%';
+--echo *** Waiting until Binlog Server log confirms that it processed an
+--echo *** the ANONYMOUS_GTID_LOG event with sequence_number which is equal
+--echo *** to the number of inserts we executed.
+# the fact there could be unprocessed events after ANONYMOUS_GTID_LOG
+# with sequence_number == $number_of_inserts does not change the logic
+# of this test case (for us what matters is that the storage memory buffer
+# has some data that hasn't been flushed).
+--let $grep_file = $binsrv_log_path
+--let $grep_pattern = sequence_number: $number_of_inserts
 --let $wait_timeout = 60
---source include/wait_condition.inc
+--source include/wait_for_pattern_in_file.inc
 
 --echo
 --echo *** Capturing storage object size before checkpoint, rotate, timeout, or graceful shutdown.

--- a/mtr/binlog_streaming/t/gtid_rewrite_enforce_checksums.combinations
+++ b/mtr/binlog_streaming/t/gtid_rewrite_enforce_checksums.combinations
@@ -1,8 +1,8 @@
 [gtid_on_checksum_on]
-enforce-gtid-consistency = ON
+enforce-gtid-consistency
 gtid-mode = ON
 
 [gtid_on_checksum_off]
-enforce-gtid-consistency = ON
+enforce-gtid-consistency
 gtid-mode = ON
 binlog-checksum=NONE


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PBS-18

Reworked 'binlog_streaming.binlog_flush' MTR test case. As an indicator
of the fact that in-memory storage buffer inside PBS has some data that
has not been flushed we now rely on the presence of the parsed
ANONYMOUS_GTID_LOG binlog event in the PBS log file that has
'sequence_number' field equal to the number of inserts we have performed.

Removed the '.combinations' file for this test as it was originally
intended to be created for position-based replication (where we have
ANONYMOUS_GTID_LOG events).