### PR TITLE
PBS-20 feature: Update project to use c++23 (part 1)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,6 +7,7 @@ on:
     branches: [ "main" ]
 
 env:
+  CPP_LANGUAGE_STANDARD_LABEL: cxx23
   AWS_SDK_CPP_MAJOR: 1
   AWS_SDK_CPP_MINOR: 11
   AWS_SDK_CPP_PATCH: 774
@@ -179,7 +180,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{github.workspace}}/boost-install-${{matrix.config.label}}
-        key: ${{format('boost-static-libraries-{0}-{1}-{2}-{3}', env.BOOST_MAJOR, env.BOOST_MINOR, env.BOOST_PATCH, matrix.config.label)}}
+        key: ${{format('boost-static-libraries-{0}-{1}-{2}-{3}-{4}', env.BOOST_MAJOR, env.BOOST_MINOR, env.BOOST_PATCH, env.CPP_LANGUAGE_STANDARD_LABEL, matrix.config.label)}}
 
     - name: Checking out Boost source tree
       if: steps.cache-boost-static-libraries.outputs.cache-hit != 'true'
@@ -205,7 +206,7 @@ jobs:
 
     - name: Build for Boost
       if: steps.cache-boost-static-libraries.outputs.cache-hit != 'true'
-      run: cmake --build ${{github.workspace}}/boost-build-${{matrix.config.label}} --parallel
+      run: cmake --build ${{github.workspace}}/boost-build-${{matrix.config.label}}
 
     - name: Install for Boost
       if: steps.cache-boost-static-libraries.outputs.cache-hit != 'true'
@@ -216,7 +217,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{github.workspace}}/aws-sdk-cpp-install-${{matrix.config.label}}
-        key: ${{format('aws-cpp-sdk-libraries-{0}-{1}-{2}-{3}', env.AWS_SDK_CPP_MAJOR, env.AWS_SDK_CPP_MINOR, env.AWS_SDK_CPP_PATCH, matrix.config.label)}}
+        key: ${{format('aws-cpp-sdk-libraries-{0}-{1}-{2}-{3}-{4}', env.AWS_SDK_CPP_MAJOR, env.AWS_SDK_CPP_MINOR, env.AWS_SDK_CPP_PATCH, env.CPP_LANGUAGE_STANDARD_LABEL, matrix.config.label)}}
 
     - name: Checking out AWS SDK C++ source tree
       if: steps.cache-aws-sdk-cpp-libraries.outputs.cache-hit != 'true'
@@ -242,7 +243,7 @@ jobs:
 
     - name: Build for AWS SDK C++
       if: steps.cache-aws-sdk-cpp-libraries.outputs.cache-hit != 'true'
-      run: cmake --build ${{github.workspace}}/aws-sdk-cpp-build-${{matrix.config.label}} --parallel
+      run: cmake --build ${{github.workspace}}/aws-sdk-cpp-build-${{matrix.config.label}}
 
     - name: Install for AWS SDK C++
       if: steps.cache-aws-sdk-cpp-libraries.outputs.cache-hit != 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ project(BinlogServer VERSION 0.4 LANGUAGES CXX)
 
 # specify the C++ standard
 add_library(binlog_server_compiler_flags INTERFACE)
-target_compile_features(binlog_server_compiler_flags INTERFACE cxx_std_20)
+target_compile_features(binlog_server_compiler_flags INTERFACE cxx_std_23)
 target_include_directories(binlog_server_compiler_flags INTERFACE "${PROJECT_SOURCE_DIR}/src")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,7 @@
       "installDir": "${sourceParentDir}/${sourceDirName}-install-${presetName}",
       "cacheVariables": {
         "CMAKE_PREFIX_PATH": "${sourceParentDir}/aws-sdk-cpp-install-${presetName};${sourceParentDir}/boost-install-${presetName}",
-        "CPP_STANDARD": "20",
+        "CPP_STANDARD": "23",
         "S2N_USE_CRYPTO_SHARED_LIBS": "ON",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "BUILD_TESTING": "ON"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `binlog_server` is a command line utility that can be considered as an enhanced version of [mysqlbinlog](https://dev.mysql.com/doc/refman/8.0/en/mysqlbinlog.html) in [--read-from-remote-server](https://dev.mysql.com/doc/refman/8.0/en/mysqlbinlog.html#option_mysqlbinlog_read-from-remote-server) mode which serves as a replication client and can stream binary log events from a remote [Oracle MySQL Server](https://www.mysql.com/) / [Percona Server for MySQL](https://www.percona.com/mysql/software/percona-server-for-mysql) both to a local filesystem and to a cloud storage (currently to `AWS S3` or `S3`-compatible service like `MinIO`). It is capable of automatically reconnecting to the remote server and resume operation from the point when it was previously stopped / terminated.
 
-It is written in portable c++ following the c++20 standard best practices.
+It is written in portable c++ following the c++23 standard best practices.
 
 ## Installation
 

--- a/extra/cmake_presets/aws-sdk-cpp/CMakePresets.json
+++ b/extra/cmake_presets/aws-sdk-cpp/CMakePresets.json
@@ -13,7 +13,7 @@
       "binaryDir": "${sourceParentDir}/${sourceDirName}-build-${presetName}",
       "installDir": "${sourceParentDir}/${sourceDirName}-install-${presetName}",
       "cacheVariables": {
-        "CPP_STANDARD": "20",
+        "CPP_STANDARD": "23",
         "ENABLE_UNITY_BUILD": "ON",
         "BUILD_SHARED_LIBS": "OFF",
         "AWS_USE_CRYPTO_SHARED_LIBS": "ON",

--- a/extra/cmake_presets/boost/CMakePresets.json
+++ b/extra/cmake_presets/boost/CMakePresets.json
@@ -13,6 +13,9 @@
       "binaryDir": "${sourceParentDir}/${sourceDirName}-build-${presetName}",
       "installDir": "${sourceParentDir}/${sourceDirName}-install-${presetName}",
       "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "23",
+        "CMAKE_CXX_STANDARD_REQUIRED": "ON",
+        "CMAKE_CXX_EXTENSIONS": "OFF",
         "CMAKE_CXX_FLAGS_INIT": "$env{ASAN_FLAGS} $env{STDLIB_FLAGS}",
         "BUILD_SHARED_LIBS": "OFF",
         "BUILD_TESTING": "OFF"


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PBS-20

Updated main 'CMakeLists.txt' file to enforce 'c++23' language standard. Updated CMake presets files used for configuring / building Boost libraries and AWS SDK CPP to use 'c++23'.

GitHub Actions scripts updated to include c++ language standard label into the keys under which Boost and AWS SDK CPP build artifacts are cached.

Updated 'README.md' to reflect c++ language standard changes.