### PR TITLE
PBS-20 feature: Update project to use c++23 (part 2)

### DIFF
--- a/src/binsrv/cout_logger.hpp
+++ b/src/binsrv/cout_logger.hpp
@@ -13,8 +13,8 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-#ifndef BINSRV_OSTREAM_LOGGER_HPP
-#define BINSRV_OSTREAM_LOGGER_HPP
+#ifndef BINSRV_COUT_LOGGER_HPP
+#define BINSRV_COUT_LOGGER_HPP
 
 #include <string_view>
 
@@ -32,4 +32,4 @@ private:
 
 } // namespace binsrv
 
-#endif // BINSRV_OSTREAM_LOGGER_HPP
+#endif // BINSRV_COUT_LOGGER_HPP

--- a/src/binsrv/events/common_header.cpp
+++ b/src/binsrv/events/common_header.cpp
@@ -19,6 +19,7 @@
 #include <iterator>
 #include <ostream>
 #include <stdexcept>
+#include <utility>
 
 #include <boost/align/align_up.hpp>
 
@@ -27,7 +28,6 @@
 #include "binsrv/events/common_header_view.hpp"
 
 #include "util/byte_span_fwd.hpp"
-#include "util/conversion_helpers.hpp"
 #include "util/ctime_timestamp.hpp"
 #include "util/exception_location_helpers.hpp"
 
@@ -41,7 +41,7 @@ common_header::common_header(
     : timestamp_(static_cast<std::uint32_t>(timestamp.get_value())),
       server_id_(server_id), event_size_(event_size),
       next_event_position_(next_event_position), flags_(flags.get_bits()),
-      type_code_(util::to_underlying(type_code)) {}
+      type_code_(std::to_underlying(type_code)) {}
 
 common_header::common_header(const common_header_view &view)
     : timestamp_{view.get_timestamp_raw()},

--- a/src/binsrv/events/format_description_body_impl.cpp
+++ b/src/binsrv/events/format_description_body_impl.cpp
@@ -20,6 +20,7 @@
 #include <ostream>
 #include <stdexcept>
 #include <string_view>
+#include <utility>
 
 #include <boost/align/align_up.hpp>
 
@@ -36,7 +37,7 @@ namespace binsrv::events {
 
 generic_body_impl<code_type::format_description>::generic_body_impl(
     checksum_algorithm_type checksum_algorithm) noexcept
-    : checksum_algorithm_{util::to_underlying(checksum_algorithm)} {}
+    : checksum_algorithm_{std::to_underlying(checksum_algorithm)} {}
 
 generic_body_impl<code_type::format_description>::generic_body_impl(
     util::const_byte_span portion) {

--- a/src/binsrv/events/gtid_tagged_log_body_impl.cpp
+++ b/src/binsrv/events/gtid_tagged_log_body_impl.cpp
@@ -28,6 +28,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <boost/lexical_cast.hpp>
 
@@ -431,71 +432,71 @@ generic_body_impl<code_type::gtid_tagged_log>::calculate_tlv_section_size()
   std::size_t total{0U};
 
   // field: flags
-  total += util::calculate_varlen_int_size(
-      util::to_underlying(field_id_type::flags));
+  total +=
+      util::calculate_varlen_int_size(std::to_underlying(field_id_type::flags));
   total += util::calculate_varlen_int_size(flags_);
 
   // field: uuid (16 separate varlen-encoded bytes, one per UUID byte)
   total +=
-      util::calculate_varlen_int_size(util::to_underlying(field_id_type::uuid));
+      util::calculate_varlen_int_size(std::to_underlying(field_id_type::uuid));
   for (auto uuid_byte : uuid_) {
-    total += util::calculate_varlen_int_size(util::to_underlying(uuid_byte));
+    total += util::calculate_varlen_int_size(std::to_underlying(uuid_byte));
   }
 
   // field: gno
   total +=
-      util::calculate_varlen_int_size(util::to_underlying(field_id_type::gno));
+      util::calculate_varlen_int_size(std::to_underlying(field_id_type::gno));
   total += util::calculate_varlen_int_size(gno_);
 
   // field: tag (varlen length + raw bytes)
   total +=
-      util::calculate_varlen_int_size(util::to_underlying(field_id_type::tag));
+      util::calculate_varlen_int_size(std::to_underlying(field_id_type::tag));
   total += util::calculate_varlen_int_size(std::size(tag_));
   total += std::size(tag_);
 
   // field: last_committed
   total += util::calculate_varlen_int_size(
-      util::to_underlying(field_id_type::last_committed));
+      std::to_underlying(field_id_type::last_committed));
   total += util::calculate_varlen_int_size(last_committed_);
 
   // field: sequence_number
   total += util::calculate_varlen_int_size(
-      util::to_underlying(field_id_type::sequence_number));
+      std::to_underlying(field_id_type::sequence_number));
   total += util::calculate_varlen_int_size(sequence_number_);
 
   // field: immediate_commit_timestamp
   total += util::calculate_varlen_int_size(
-      util::to_underlying(field_id_type::immediate_commit_timestamp));
+      std::to_underlying(field_id_type::immediate_commit_timestamp));
   total += util::calculate_varlen_int_size(immediate_commit_timestamp_);
 
   // field: original_commit_timestamp (optional)
   if (has_original_commit_timestamp()) {
     total += util::calculate_varlen_int_size(
-        util::to_underlying(field_id_type::original_commit_timestamp));
+        std::to_underlying(field_id_type::original_commit_timestamp));
     total += util::calculate_varlen_int_size(original_commit_timestamp_);
   }
 
   // field: transaction_length
   total += util::calculate_varlen_int_size(
-      util::to_underlying(field_id_type::transaction_length));
+      std::to_underlying(field_id_type::transaction_length));
   total += util::calculate_varlen_int_size(transaction_length_);
 
   // field: immediate_server_version
   total += util::calculate_varlen_int_size(
-      util::to_underlying(field_id_type::immediate_server_version));
+      std::to_underlying(field_id_type::immediate_server_version));
   total += util::calculate_varlen_int_size(immediate_server_version_);
 
   // field: original_server_version (optional)
   if (has_original_server_version()) {
     total += util::calculate_varlen_int_size(
-        util::to_underlying(field_id_type::original_server_version));
+        std::to_underlying(field_id_type::original_server_version));
     total += util::calculate_varlen_int_size(original_server_version_);
   }
 
   // field: commit_group_ticket (optional)
   if (has_commit_group_ticket()) {
     total += util::calculate_varlen_int_size(
-        util::to_underlying(field_id_type::commit_group_ticket));
+        std::to_underlying(field_id_type::commit_group_ticket));
     total += util::calculate_varlen_int_size(commit_group_ticket_);
   }
 
@@ -541,7 +542,7 @@ void generic_body_impl<code_type::gtid_tagged_log>::encode_tlv_section_to(
     util::byte_span &destination) const {
   const auto emit_field_id{[&destination](field_id_type field_id) {
     [[maybe_unused]] auto result{util::insert_varlen_int_to_byte_span_checked(
-        destination, util::to_underlying(field_id))};
+        destination, std::to_underlying(field_id))};
   }};
 
   // It is OK to ignore the result here as we already ensured
@@ -557,7 +558,7 @@ void generic_body_impl<code_type::gtid_tagged_log>::encode_tlv_section_to(
   emit_field_id(field_id_type::uuid);
   for (auto uuid_byte : uuid_) {
     insert_result = util::insert_varlen_int_to_byte_span_checked(
-        destination, util::to_underlying(uuid_byte));
+        destination, std::to_underlying(uuid_byte));
   }
 
   // field: gno

--- a/src/binsrv/s3_error_helpers_private.cpp
+++ b/src/binsrv/s3_error_helpers_private.cpp
@@ -18,12 +18,12 @@
 #include <source_location>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <aws/s3-crt/S3CrtErrors.h>
 
 #include "binsrv/s3_error.hpp"
 
-#include "util/conversion_helpers.hpp"
 #include "util/exception_location_helpers.hpp"
 
 namespace binsrv {
@@ -47,9 +47,8 @@ raise_s3_error_from_outcome(std::string_view user_message,
   message += ", RequestID ";
   message += sdk_error.GetRequestId();
   message += ", ResponseCode ";
-  // TODO: in c++23 change to std::to_underlying()
   auto http_status_code = sdk_error.GetResponseCode();
-  message += std::to_string(util::to_underlying(http_status_code));
+  message += std::to_string(std::to_underlying(http_status_code));
   message += ')';
 
   // default value std::source_location::current() for the 'location'

--- a/src/binsrv/s3_storage_backend.cpp
+++ b/src/binsrv/s3_storage_backend.cpp
@@ -121,6 +121,7 @@ public:
   struct endpoint_tag {};
 
   using stream_factory_type = std::function<std::iostream *()>;
+  // TODO: change to std::move_only_function when libc++ supports it
   using stream_handler_type = std::function<void(std::size_t, std::iostream &)>;
 
   aws_context(bucket_tag tag, const simple_aws_credentials &credentials,
@@ -680,7 +681,7 @@ void s3_storage_backend::init_with_endpoint(
 
   if (uri_path_it == std::cend(uri_path)) {
     util::exception_location().raise<std::invalid_argument>(
-        "endpoint s3 URI path must include at least on segment");
+        "endpoint s3 URI path must include at least one segment");
   }
   bucket_ = *uri_path_it;
   ++uri_path_it;

--- a/src/easymysql/connection.cpp
+++ b/src/easymysql/connection.cpp
@@ -183,12 +183,12 @@ private:
   MYSQL_RPL rpl_;
 
   // MYSQL_RPL_SKIP_HEARTBEAT
-  // https://github.com/mysql/mysql-server/blob/mysql-cluster-8.0.43/include/mysql.h#L366
-  // https://github.com/mysql/mysql-server/blob/mysql-cluster-8.4.6/include/mysql.h#L367
+  // https://github.com/mysql/mysql-server/blob/mysql-8.0.43/include/mysql.h#L366
+  // https://github.com/mysql/mysql-server/blob/mysql-8.4.6/include/mysql.h#L367
 
   // USE_HEARTBEAT_EVENT_V2
-  // https://github.com/mysql/mysql-server/blob/mysql-cluster-8.0.43/include/mysql.h#L372
-  // https://github.com/mysql/mysql-server/blob/mysql-cluster-8.4.6/include/mysql.h#L373
+  // https://github.com/mysql/mysql-server/blob/mysql-8.0.43/include/mysql.h#L372
+  // https://github.com/mysql/mysql-server/blob/mysql-8.4.6/include/mysql.h#L373
 
   // Explaining BINLOG_DUMP_NON_BLOCK
   // https://github.com/mysql/mysql-server/blob/mysql-8.0.43/sql/rpl_constants.h#L45

--- a/src/util/byte_span_extractors.hpp
+++ b/src/util/byte_span_extractors.hpp
@@ -23,8 +23,7 @@
 #include <cstddef>
 #include <cstring>
 #include <limits>
-
-#include <boost/endian/conversion.hpp>
+#include <utility>
 
 #include "util/byte_span_fwd.hpp"
 #include "util/byte_span_packed_int_constants.hpp"
@@ -46,11 +45,13 @@ void extract_fixed_int_from_byte_span(
                 bytes_to_extract);
     // A fixed-length unsigned integer stores its value in a series of
     // bytes with the least significant byte first.
-    // TODO: in c++23 use std::byteswap()
-    value = boost::endian::little_to_native(value_in_network_format);
+    if constexpr (std::endian::native == std::endian::little) {
+      value = value_in_network_format;
+    } else {
+      value = std::byteswap(value_in_network_format);
+    }
   } else {
-    // TODO: in c++23 change use std::to_underlying(*std::data(remainder))
-    value = static_cast<T>(util::to_underlying(*std::data(remainder)));
+    value = static_cast<T>(std::to_underlying(*std::data(remainder)));
   }
   remainder = remainder.subspan(bytes_to_extract);
 }

--- a/src/util/byte_span_inserters.hpp
+++ b/src/util/byte_span_inserters.hpp
@@ -24,8 +24,6 @@
 #include <cstring>
 #include <limits>
 
-#include <boost/endian/conversion.hpp>
-
 #include "util/byte_span_fwd.hpp"
 #include "util/byte_span_packed_int_constants.hpp"
 #include "util/conversion_helpers.hpp"
@@ -43,8 +41,12 @@ void insert_fixed_int_to_byte_span(
   if constexpr (sizeof(T) != 1U) {
     // A fixed-length unsigned integer stores its value in a series of
     // bytes with the least significant byte first.
-    // TODO: in c++23 use std::byteswap()
-    T value_in_network_format{boost::endian::native_to_little(value)};
+    T value_in_network_format{};
+    if constexpr (std::endian::native == std::endian::little) {
+      value_in_network_format = value;
+    } else {
+      value_in_network_format = std::byteswap(value);
+    }
     std::memcpy(std::data(remainder), &value_in_network_format,
                 bytes_to_insert);
   } else {

--- a/src/util/conversion_helpers.hpp
+++ b/src/util/conversion_helpers.hpp
@@ -18,6 +18,7 @@
 
 #include <concepts>
 #include <type_traits>
+#include <utility>
 
 namespace util {
 
@@ -28,15 +29,6 @@ template <std::integral To, std::integral From>
   } else {
     return static_cast<To>(value);
   }
-}
-
-// TODO: remove this function when switch to c++23 and use std::to_underlying
-//       instead
-template <typename EnumType>
-  requires std::is_enum_v<EnumType>
-[[nodiscard]] constexpr std::underlying_type_t<EnumType>
-to_underlying(EnumType enum_value) noexcept {
-  return static_cast<std::underlying_type_t<EnumType>>(enum_value);
 }
 
 template <typename EnumType>
@@ -52,7 +44,7 @@ template <typename EnumType>
            sizeof(std::underlying_type_t<EnumType>) <= sizeof(std::size_t))
 [[nodiscard]] constexpr std::size_t
 enum_to_index(EnumType enum_value) noexcept {
-  return static_cast<std::size_t>(to_underlying(enum_value));
+  return static_cast<std::size_t>(std::to_underlying(enum_value));
 }
 
 template <typename EnumType>

--- a/src/util/redirectable.hpp
+++ b/src/util/redirectable.hpp
@@ -13,8 +13,8 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-#ifndef UTIL_REDIRECTABLE_FWD_HPP
-#define UTIL_REDIRECTABLE_FWD_HPP
+#ifndef UTIL_REDIRECTABLE_HPP
+#define UTIL_REDIRECTABLE_HPP
 
 namespace util {
 
@@ -23,4 +23,4 @@ concept redirectable = requires { typename T::redirect_type; };
 
 } // namespace util
 
-#endif // UTIL_REDIRECTABLE_FWD_HPP
+#endif // UTIL_REDIRECTABLE_HPP


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PBS-20

More c++23 improvements:
* removed 'util::to_underlying()' - use 'std::to_underlying()' instead
* using 'std::byteswap()' instead of 'boost::endian::little_to_native()' now.

Please note that 'std::move_only_function' still cannot be used as it hasn't been implemented in 'libc++'.

Fixed some include header guards names that did not follow naming conventions. Fixed some typos.
Fixed some GitHub link references in the source code comments.